### PR TITLE
【ヘッダー】認証画面用のヘッダーパーシャルの実装

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def auth_page?
+    devise_controller? && %w[sessions registrations].include?(controller_name) && action_name == 'new'
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def auth_page?
-    devise_controller? && %w[sessions registrations].include?(controller_name) && action_name == 'new'
+    devise_controller? && %w[sessions registrations].include?(controller_name) && action_name == "new"
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,9 @@
-<% if user_signed_in? %>
-  <%= render 'shared/header_user' %>
+<% if auth_page? %>
+  <%= render 'shared/header_auth' %>
 <% else %>
-  <%= render 'shared/header_guest' %>
+  <% if user_signed_in? %>
+    <%= render 'shared/header_user' %>
+  <% else %>
+    <%= render 'shared/header_guest' %>
+  <% end %>
 <% end %> 

--- a/app/views/shared/_header_auth.html.erb
+++ b/app/views/shared/_header_auth.html.erb
@@ -1,0 +1,5 @@
+<header class="bg-slate-200">
+  <div class="flex justify-between items-center p-4 gap-10">
+    <%= image_tag "logo.png", class: "flex-none size-16" %>
+  </div>
+</header> 


### PR DESCRIPTION
## 概要
- #44 

**認証画面用のヘッダーパーシャルの実装**を行った。
また、ヘッダーパーシャルにおいて、条件分岐を追加し、認証画面時には、`app/views/shared/_header_auth.html.erb`が表示されるように変更した。

## 行った変更点
### 認証画面用ヘッダーの作成
`app/views/shared/_header_auth.html.erb`
<img width="1440" alt="スクリーンショット 2025-07-08 19 52 56" src="https://github.com/user-attachments/assets/f4f7cf67-d890-43d1-83db-91358a44f0bb" />

- [x] 認証画面用のヘッダーパーシャルを作成し、ロゴのみを表示する。

### ヘッダーの条件分岐の追加
`app/views/shared/_header.html.erb`
```erb
<% if auth_page? %>
  <%= render 'shared/header_auth' %>
<% else %>
  <% if user_signed_in? %>
    <%= render 'shared/header_user' %>
  <% else %>
    <%= render 'shared/header_guest' %>
  <% end %>
<% end %> 
```
- [x] ヘッダーパーシャル表示に関する条件分岐を修正する。