### PR TITLE
【ログイン画面】Deviseのゲストユーザーを実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,9 +4,61 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  helper_method :current_or_guest_user
+
+  # --------------以下ゲストユーザー関連のコード--------------
+  protect_from_forgery
+
+  def current_or_guest_user
+    if current_user
+      if session[:guest_user_id] && session[:guest_user_id] != current_user.id
+        logging_in
+        # reload guest_user to prevent caching problems before destruction
+        guest_user(with_retry = false).try(:reload).try(:destroy)
+        session[:guest_user_id] = nil
+      end
+      current_user
+    else
+      guest_user
+    end
+  end
+  
+  # find guest_user object associated with the current session,
+  # creating one as needed
+  def guest_user(with_retry = true)
+    # Cache the value the first time it's gotten.
+    @cached_guest_user ||= User.find(session[:guest_user_id] ||= create_guest_user.id)
+    
+  rescue ActiveRecord::RecordNotFound # if session[:guest_user_id] invalid
+    session[:guest_user_id] = nil
+    guest_user if with_retry
+  end
+
+  # --------------ここまでゲストユーザー関連のコード--------------
+  
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+  end
+
+  private
+  
+  # called (once) when the user logs in, insert any code your application needs
+  # to hand off from guest_user to current_user.
+  def logging_in
+    # For example:
+    # guest_comments = guest_user.comments.all
+    # guest_comments.each do |comment|
+      # comment.user_id = current_user.id
+      # comment.save!
+    # end
+  end
+
+  def create_guest_user
+    u = User.new(name: "guest", email: "guest_#{Time.now.to_i}#{rand(100)}@example.com")
+    u.save!(validate: false)
+    session[:guest_user_id] = u.id
+    u
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,20 +22,20 @@ class ApplicationController < ActionController::Base
       guest_user
     end
   end
-  
+
   # find guest_user object associated with the current session,
   # creating one as needed
   def guest_user(with_retry = true)
     # Cache the value the first time it's gotten.
     @cached_guest_user ||= User.find(session[:guest_user_id] ||= create_guest_user.id)
-    
+
   rescue ActiveRecord::RecordNotFound # if session[:guest_user_id] invalid
     session[:guest_user_id] = nil
     guest_user if with_retry
   end
 
   # --------------ここまでゲストユーザー関連のコード--------------
-  
+
   protected
 
   def configure_permitted_parameters
@@ -43,15 +43,15 @@ class ApplicationController < ActionController::Base
   end
 
   private
-  
+
   # called (once) when the user logs in, insert any code your application needs
   # to hand off from guest_user to current_user.
   def logging_in
     # For example:
     # guest_comments = guest_user.comments.all
     # guest_comments.each do |comment|
-      # comment.user_id = current_user.id
-      # comment.save!
+    # comment.user_id = current_user.id
+    # comment.save!
     # end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super
+    current_or_guest_user
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,7 +12,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     super
-    current_or_guest_user
+    current_or_guest_user # 主にはゲストユーザーからログイン中のユーザーへのデータの引き継ぎ
   end
 
   # GET /resource/edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,10 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    super
+    current_or_guest_user
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,13 @@ class Users::SessionsController < Devise::SessionsController
   # POST /resource/sign_in
   def create
     super
-    current_or_guest_user
+    current_or_guest_user # 主にはゲストユーザーからログイン中のユーザーへのデータの引き継ぎ
+  end
+
+  # ゲストユーザー作成アクション
+  def create_guest
+    guest_user
+    redirect_to root_path
   end
 
   # DELETE /resource/sign_out

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,16 +26,18 @@
     <div class="min-h-screen flex flex-col">
       <%= render 'shared/header' %>
       
-      <% if Rails.env.development? && user_signed_in? %>
+      <% if Rails.env.development? %>
         <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
           <div class="flex">
             <div class="ml-3">
               <h3 class="text-sm font-medium">開発用デバッグ情報</h3>
               <div class="mt-2 text-sm">
-                <p><strong>ユーザー名:</strong> <%= current_user.name %></p>
-                <p><strong>メールアドレス:</strong> <%= current_user.email %></p>
-                <p><strong>ユーザーID:</strong> <%= current_user.id %></p>
-                <p><strong>作成日時:</strong> <%= current_user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+                <p><strong>session[:guest_user_id]:</strong> <%= session[:guest_user_id] %></p>
+                <p><strong>ユーザーID:</strong> <%= current_or_guest_user.id %></p>
+                <p><strong>ユーザー名:</strong> <%= current_or_guest_user.name %></p>
+                <p><strong>メールアドレス:</strong> <%= current_or_guest_user.email %></p>
+                
+                <p><strong>作成日時:</strong> <%= current_or_guest_user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
               </div>
             </div>
           </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <div class="flex flex-col items-center h-full gap-10 my-10">
   <p class="text-2xl font-bold">Log in</p>
 
+  <%= button_to "create guest user", guest_session_path, class: "btn btn-primary" %>
+  
   <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-10" }) do |f| %>
     <div class="field">
       <%= f.label :email %><br />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,11 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
+  
+  # ゲストユーザー作成用ルート
+  devise_scope :user do
+    post '/users/guest', to: 'users/sessions#create_guest', as: :guest_session
+  end
+
   root "static_pages#top"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,10 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
-  
+
   # ゲストユーザー作成用ルート
   devise_scope :user do
-    post '/users/guest', to: 'users/sessions#create_guest', as: :guest_session
+    post "/users/guest", to: "users/sessions#create_guest", as: :guest_session
   end
 
   root "static_pages#top"


### PR DESCRIPTION
## 概要
- #19 
- gusti-amber/devise_app#6

上記のDeviseのゲストユーザー実装を検証したブランチの内容(`devise_app#6`)を参考にしながら、**Deviseのゲストユーザーを作成する機能**を実装した。
また、**ログイン画面に「ゲストユーザーとして利用」ボタンを追加**し、ボタンを押すと「ゲストユーザーのUserオブジェクト」と「セッション値」が生成されていることを確認した。

## 行った変更

### Deviseのゲストユーザーを作成する機能を実装
`app/controllers/application_controller.rb`
- [x] ゲストユーザーを作成するメソッドの追加

### ユーザー登録用とログイン/ログアウト用のコントローラーのcreateアクションをオーバーライド
`app/controllers/users/sessions_controller.rb`
`app/controllers/users/registrations_controller.rb`
- [x] ログイン用のコントローラーにゲストユーザーを作成するアクションを追加
  - createアクション（認証してログイン）とゲストユーザーを作成するアクションは分ける意図がある。
- [x] ゲストユーザーを作成するルーティングを追加

### ログイン画面からゲストユーザーを作成する
`app/views/users/sessions/new.html.erb`
- [x] 「ゲストユーザーとして利用」ボタンを追加
<img width="1440" alt="スクリーンショット 2025-07-10 10 51 55" src="https://github.com/user-attachments/assets/8ce26f1d-9c36-4291-8c7d-3877de3ffbef" />

- [x] ボタンを押すと「ゲストユーザーのUserオブジェクト」と「セッション値」が生成されていることを確認
<img width="1440" alt="スクリーンショット 2025-07-10 10 52 03" src="https://github.com/user-attachments/assets/7cc44017-010f-4c33-b726-7a5f2c4bee2c" />

### 気になった点
- `current_or_guest_user`メソッドは複数の役割を持っているため、「ゲストユーザーのデータ引き継ぎ」と「ゲストユーザーの取得・作成」はそれぞれ別のメソッドに分けるべきだと考えられる。
- 上記の`current_or_guest_user`メソッドの変更に伴って、sessionsコントローラーのcreateアクション、create_guestアクションも書き換えるべきだと考えられる。
```ruby
# app/controllers/users/sessions_controller.rb

class Users::SessionsController < Devise::SessionsController
  # POST /resource/sign_in
  def create
    super
    current_or_guest_user # 主にはゲストユーザーからログイン中のユーザーへのデータの引き継ぎ
  end

  # ゲストユーザー作成アクション
  def create_guest
    guest_user
    redirect_to root_path
  end
.
.
.
```