### PR TITLE
【テスト】Userモデルスペックの作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # カスタムバリデーション
+  validates :name, presence: true, length: { minimum: 2, maximum: 50 }
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :user do
-    
+    name { "amber" }
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it '設定したすべてのバリデーションが機能しているか' do
+      user = build(:user)
+      expect(user).to be_valid
+      expect(user.errors).to be_empty
+    end
+
+    it 'nameがない場合、バリデーションが機能し、invalidになる' do
+      user = build(:user, name: nil)
+      expect(user).to be_invalid
+      expect(user.errors[:name]).to include("can't be blank")
+    end
+
+    it 'nameが1文字の場合、バリデーションが機能し、invalidになる' do
+      user = build(:user, name: 'A')
+      expect(user).to be_invalid
+      expect(user.errors[:name]).to include('is too short (minimum is 2 characters)')
+    end
+
+    it 'nameが51文字の場合、バリデーションが機能し、invalidになる' do
+      user = build(:user, name: 'A' * 51)
+      expect(user).to be_invalid
+      expect(user.errors[:name]).to include('is too long (maximum is 50 characters)')
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,4 @@
+# RspecでFactoryBotのメソッドを使用する際に、モジュール名を省略するための設定
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods 
+end 

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,4 +1,4 @@
 # RspecでFactoryBotのメソッドを使用する際に、モジュール名を省略するための設定
 RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods 
-end 
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
## 概要
- #49 
Userモデルのモデルスペックを作成する。

### 参考記事
#### factory_botのはじめ方
https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md

## 行った変更
### Rspecでfactory_botのメソッドを使用するための設定
https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#configure-your-test-suite

- 手動で設定ファイルを作成し、以下のように記述する。
```zsh
mkdir -p spec/support
```
```zsh
touch spec/support/factory_bot.rb
```
```ruby
# spec/support/factory_bot.rb

RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end
```

- `spec/rails_helper.rb`26行目付近のコメントアウトを外し、先ほどの設定ファイルを読み込む
```ruby
# spec/rails_helper.rb 26行目付近
Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
```

### モデルスペックの作成
https://github.com/rspec/rspec-rails?tab=readme-ov-file#usage

- Userモデルのモデルスペックを生成
```zsh
docker compose exec web rails generate rspec:model user
```

- Userのnameカラムのバリデーションチェックを記述