### PR TITLE
【タスク詳細画面】画面の簡易実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,6 +18,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task = current_or_guest_user.tasks.includes(:tags).find(params[:id])
   end
 
   def edit

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,48 @@
+<div class="bg-white rounded-lg shadow-lg p-6 relative m-10">
+  <div class="flex justify-between items-center">
+    <!-- タイトル -->
+    <div class="flex flex-col">
+      <p class="text-2xl font-bold mb-6">
+        <%= @task.title %>
+      </p>
+
+      <!-- タグ -->
+      <% if @task.tags.any? %>
+        <div class="flex flex-wrap gap-2 mb-8">
+          <% @task.tags.each do |tag| %>
+            <span class="badge badge-primary">#<%= tag.name %></span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- ボタン群 -->
+    <div class="flex flex-col">
+      <!-- 編集ボタン -->
+      <%= link_to edit_task_path(@task), class: "btn btn-primary" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+        </svg>
+        編集
+      <% end %>
+
+      <!-- 完了ボタン -->
+      <%= link_to "#", class: "btn btn-secondary" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+        </svg>
+        完了
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- 戻るボタン -->
+<div class="mt-6 text-center">
+  <%= link_to tasks_path, class: "btn btn-primary" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+    </svg>
+    戻る
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
- #23 

画面遷移図を元にタスク詳細画面を簡易実装した。また、Taskコントローラーのshowアクションを記述した。

### タスク詳細画面
`app/controllers/tasks_controller.rb`
```ruby
def show
    @task = current_or_guest_user.tasks.includes(:tags).find(params[:id])
end
```
- [x] showアクションを記述

`app/views/tasks/show.html.erb`
<img width="1440" height="900" alt="スクリーンショット 2025-07-16 12 18 12" src="https://github.com/user-attachments/assets/56a16eb1-ec46-4038-977a-b886ab8fbb53" />

- [x] タスク詳細の領域を設置
  - [x] タイトル
  - [x] タグ
  - [x] 「編集」ボタン、押すとタスク編集画面へ遷移
  - [x] 「完了」ボタン
  - [x] 「戻る」ボタン、押すとタスク一覧画面へ遷移