### PR TITLE
【タスク編集画面】Todoリストの追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,7 +22,7 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = current_or_guest_user.tasks.includes(:tags).find(params[:id])
+    @task = current_or_guest_user.tasks.includes(:tags, :todos).find(params[:id])
   end
 
   def update
@@ -41,6 +41,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, tag_ids: [])
+    params.require(:task).permit(:title, tag_ids: [], todos_attributes: [:id, :body, :done, :_destroy])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -41,6 +41,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, tag_ids: [], todos_attributes: [:id, :body, :done, :_destroy])
+    params.require(:task).permit(:title, tag_ids: [], todos_attributes: [ :id, :body, :done, :_destroy ])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
 
   has_many :tasktags
   has_many :tags, through: :tasktags
+  has_many :todos, dependent: :destroy
 
   enum status: { todo: 0, doing: 1, done: 2 }
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,10 @@ class Task < ApplicationRecord
   has_many :tags, through: :tasktags
   has_many :todos, dependent: :destroy
 
+  # 🎓 reject_if: :all_blank について、:all_blankが渡されると、_destroyの値を除くすべての属性が空白レコードを受け付けなくなるprocが1つ生成されます。
+  #   つまり、_destroyの値を除くすべての属性に値がないと、レコードが作成されないようになる。
+  accepts_nested_attributes_for :todos, allow_destroy: true, reject_if: :all_blank
+
   enum status: { todo: 0, doing: 1, done: 2 }
 
   validates :title, presence: true, length: { minimum: 2, maximum: 255 }

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,0 +1,3 @@
+class Todo < ApplicationRecord
+  belongs_to :task
+end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,3 +1,5 @@
 class Todo < ApplicationRecord
   belongs_to :task
+
+  validates :body, presence: true, length: { maximum: 200 }
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -60,24 +60,40 @@
         <!-- ♻️タグ検索セクション 将来的に以下の実装で行いたいが、jsがまだ理解不足なので置いておく-->
         <%#= render partial: "tag_search_form", locals: { f: f, task: @task } %>
 
-        <!-- ここまで読みました(2025/07/17) -->
         <!-- やることリストセクション（プレースホルダー） -->
         <div class="form-control">
           <div class="flex items-center justify-between mb-3">
             <!-- ♻️ここはf.labelに変更予定 -->
-            <h3 class="text-lg font-medium">やること</h3>
-            <button type="button" class="btn btn-ghost btn-sm">
+            <%= f.label :todos, class: "label" %>
+            <button type="button" class="btn btn-ghost btn-sm" onclick="addTodoField()">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
               </svg>
               <span>追加</span>
             </button>
           </div>
-          <!-- ♻️ここはtodoモデル作成後に、f.text_fieldに変更予定 -->
-          <div class="space-y-2">
-            <input type="text" placeholder="やること1" class="input input-bordered w-full" disabled>
-            <input type="text" placeholder="やること2" class="input input-bordered w-full" disabled>
-            <input type="text" placeholder="やること3" class="input input-bordered w-full" disabled>
+
+          <!-- Todoリストの表示・編集フォーム -->
+          <!-- 🐛 todoリストの幅が不当に狭くなっている。以前はflexが原因だった。 -->
+          <div id="todos-container" class="space-y-2">
+            <%= f.fields_for :todos do |todo_form| %>
+              <div class="flex items-center gap-2">                
+                <!-- 削除ボタン -->
+                <button type="button" 
+                        class="btn btn-circle btn-outline btn-error btn-sm"
+                        onclick="removeTodoField(this)">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                    <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
+                  </svg>
+                </button>
+                <!-- todo入力フィールド -->
+                <%= todo_form.text_field :body, 
+                    placeholder: "やることを入力してください", 
+                    class: "input input-bordered flex-1" %>
+                <%= todo_form.hidden_field :id %>
+                <%= todo_form.hidden_field :_destroy, class: "hidden" %>
+              </div>
+            <% end %>
           </div>
         </div>
 
@@ -91,19 +107,48 @@
   </div>
 </div>
 
-<%# <script>
-function toggleTagDropdown() {
-  const dropdown = document.getElementById('tagDropdown');
-  dropdown.classList.toggle('hidden');
+<!-- ♻️ jsは今後すべてStimulusコントローラーに移す予定 -->
+<script>
+function addTodoField() {
+  const container = document.getElementById('todos-container');
+  const todoCount = container.children.length; // 🎓 todoの数、つまり新しいtodoのindexを取得
+  
+  // ♻️ この箇所は今後formオブジェクトを使った書き方に変更予定(CSRF対策、エラーハンドリングなどが欲しいため)
+  // 方法としては、<template>タグ内でf.fields_forを使う。
+  const newTodoHtml = `
+    <div class="flex items-center gap-2">
+      <button type="button" 
+              class="btn btn-circle btn-outline btn-error btn-sm"
+              onclick="removeTodoField(this)">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+          <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
+        </svg>
+      </button>
+      <input type="hidden" name="task[todos_attributes][${todoCount}][_destroy]" value="0" class="hidden">
+      <input type="text" 
+              name="task[todos_attributes][${todoCount}][body]" 
+              placeholder="やることを入力してください" 
+              class="input input-bordered flex-1">
+      <input type="hidden" name="task[todos_attributes][${todoCount}][id]" value="">
+    </div>
+  `;
+  container.insertAdjacentHTML('beforeend', newTodoHtml); // 🎓 'beforeend'により、</div>の直前に新しいtodoを追加する。
 }
 
-// ドロップダウン外をクリックした時に閉じる
-document.addEventListener('click', function(event) {
-  const dropdown = document.getElementById('tagDropdown');
-  const button = event.target.closest('button');
-  
-  if (!dropdown.contains(event.target) && !button) {
-    dropdown.classList.add('hidden');
+function removeTodoField(button) {
+  const todoForm = button.closest('.flex');
+  const todoId = todoForm.querySelector('input[type="hidden"][name$="[id]"]').value;
+  const todoDestroyField = todoForm.querySelector('input[type="hidden"][name$="[_destroy]"]');
+
+  if (confirm('このtodoを削除しますか？')) {
+    if (todoId) {
+      // 既存のtodoの場合、_destroyフィールドを設定して削除マーク
+      todoDestroyField.value = '1';
+      todoForm.style.display = 'none'; // 🎓 Railsで削除対象を特定するためにDOM要素を残す必要がある。
+    } else {
+      // 新規追加のtodoの場合、直接削除
+      todoForm.remove(); // DOM要素ごと削除
+    }
   }
-});
-</script> %>
+}
+</script>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -14,6 +14,16 @@
           <% end %>
         </div>
       <% end %>
+
+      <!-- タスクのTodoリスト -->
+      <div class="flex flex-col gap-2">
+        <% @task.todos.each do |todo| %>
+          <div class="flex items-center gap-2">
+            <input type="checkbox" class="checkbox" <%= todo.done? ? "checked" : "" %>>
+            <%= todo.body %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <!-- ボタン群 -->

--- a/db/migrate/20250717081334_create_todos.rb
+++ b/db/migrate/20250717081334_create_todos.rb
@@ -2,8 +2,8 @@ class CreateTodos < ActiveRecord::Migration[7.2]
   def change
     create_table :todos do |t|
       t.references :task, null: false, foreign_key: true
-      t.string :body
-      t.boolean :done
+      t.string :body, null: false
+      t.boolean :done, default: false, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250717081334_create_todos.rb
+++ b/db/migrate/20250717081334_create_todos.rb
@@ -1,0 +1,11 @@
+class CreateTodos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :todos do |t|
+      t.references :task, null: false, foreign_key: true
+      t.string :body
+      t.boolean :done
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_15_060742) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_17_081334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_15_060742) do
     t.index ["task_id"], name: "index_tasktags_on_task_id"
   end
 
+  create_table "todos", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.string "body", null: false
+    t.boolean "done", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_todos_on_task_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -54,4 +63,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_15_060742) do
   add_foreign_key "tasks", "users"
   add_foreign_key "tasktags", "tags"
   add_foreign_key "tasktags", "tasks"
+  add_foreign_key "todos", "tasks"
 end

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :todo do
+    task { nil }
+    body { "MyString" }
+    done { false }
+  end
+end

--- a/spec/models/todo_spec.rb
+++ b/spec/models/todo_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Todo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- #25 

Todoモデルを作成し、タスク詳細画面でtodoリストを表示した。

### Todoモデル作成
**TaskとTodoは多対1の関係。**

<img width="2336" height="540" alt="Image" src="https://github.com/user-attachments/assets/64cb5155-58fa-467d-8ef7-0ff3e34c8ba6" />

- [x] 以下のカラムを持つTodoモデルを作成
  - [x] task_id(FK)
  - [x] body(String)
  - [x] done(Boolean)

### Todoの編集機能を実装する
[Railsガイド Action View フォームヘルパー 9 複雑なフォームを作成する](https://railsguides.jp/v7.2/form_helpers.html#%E8%A4%87%E9%9B%91%E3%81%AA%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)

#### タスクコントローラー
`app/controllers/tasks_controller.rb`
- [x] editアクションを記述
- [x] Strong Parametersでtodoを許可するように設定

#### タスク編集画面
`app/views/tasks/edit.html.erb`

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/78a4bb16-cd8a-45d1-94de-cee3db0f03c1" />

- [x] todoの入力フォーム

以下、「追加」ボタンとxボタンの実装方針について
- jsで記述
- 「追加」ボタンを押すと、todo入力フォームが追加される。ここではまだDB上でtodoは作成されない。「変更」ボタンを押すことで、todoが新規作成される。
- xボタンを押すと、todo入力フォームが削除される。ここではまだDB上でtodoは削除されない。「変更」ボタンを押すことで、todoが削除される。
- 上記ボタンを押した後、「戻る」ボタンを押した場合は、データは更新されない。

- [x] 追加ボタン、押すとtodo入力フォームが追加される
- [x] todo入力フォーム左側にxボタンを設置、押すとフォームが削除される

### 今後実装・修正予定の箇所
- todoリストの幅が不当に狭くなっている。以前はflexが原因であったが未検証。
- jsはStimulusコントローラーに移植予定
- jsのaddTodoField()関数は追加するDOM要素が生の<input>なので、formオブジェクトを使った書き方に変更予定(CSRF対策、エラーハンドリングなどが欲しいため)