### PR TITLE
【タスク詳細画面】Todoリストのトグル機能

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,0 +1,14 @@
+class TodosController < ApplicationController
+  before_action :set_todo, only: [:update]
+
+  def update
+    @todo.update(done: !@todo.done?) # 現在はtodoで変更できることはdoneカラムのトグルのみだが、今後bodyカラムも更新をする場合はここを変更する
+    render partial: "todos/todo", locals: { todo: @todo }
+  end
+
+  private
+
+  def set_todo
+    @todo = current_or_guest_user.tasks.find(params[:task_id]).todos.find(params[:id])
+  end
+end 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,5 +1,5 @@
 class TodosController < ApplicationController
-  before_action :set_todo, only: [:update]
+  before_action :set_todo, only: [ :update ]
 
   def update
     @todo.update(done: !@todo.done?) # 現在はtodoで変更できることはdoneカラムのトグルのみだが、今後bodyカラムも更新をする場合はここを変更する
@@ -11,4 +11,4 @@ class TodosController < ApplicationController
   def set_todo
     @todo = current_or_guest_user.tasks.find(params[:task_id]).todos.find(params[:id])
   end
-end 
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,7 +2,10 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application"
+import { application } from "./application";
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import HelloController from "./hello_controller";
+application.register("hello", HelloController);
+
+import TodoToggleController from "./todo_toggle_controller";
+application.register("todo-toggle", TodoToggleController);

--- a/app/javascript/controllers/todo_toggle_controller.js
+++ b/app/javascript/controllers/todo_toggle_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["checkbox"];
+
+  toggle(event) {
+    const form = event.target.closest("form");
+    if (form) {
+      form.requestSubmit();
+    }
+  }
+}

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -2,4 +2,8 @@ class Todo < ApplicationRecord
   belongs_to :task
 
   validates :body, presence: true, length: { maximum: 200 }
+
+  def done?
+    done
+  end
 end

--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -1,0 +1,88 @@
+<!-- タイトル -->
+<div class="flex flex-col gap-4">
+  <div class="flex justify-between">
+    <p class="text-2xl font-bold mb-6">
+      <%= @task.title %>
+    </p>
+
+    <!-- 編集ボタン -->
+    <%= link_to edit_task_path(@task), class: "btn btn-primary" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+      </svg>
+      編集
+    <% end %>
+  </div>
+
+  <!-- タグ -->
+  <% if @task.tags.any? %>
+    <div class="flex flex-wrap gap-2 mb-8">
+      <% @task.tags.each do |tag| %>
+        <span class="badge badge-primary">#<%= tag.name %></span>
+      <% end %>
+    </div>
+  <% end %>
+
+  <!-- タスクのTodoリスト -->
+  <div class="flex justify-between">
+    <div class="flex flex-col gap-2" data-controller="todo-toggle">
+      <% @task.todos.each do |todo| %>
+        <%= render "todos/todo", todo: todo %>
+      <% end %>
+    </div>
+    <!-- 完了ボタン -->
+    <div class="flex flex-col justify-end">
+      <%= link_to "#", class: "btn btn-secondary" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+        </svg>
+        完了
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- 以前のタスク項目の表示
+<div class="flex justify-between items-center min-h-[400px]">
+  <div class="flex flex-col">
+    <p class="text-2xl font-bold mb-6">
+      <%= @task.title %>
+    </p>
+
+    
+    <% if @task.tags.any? %>
+      <div class="flex flex-wrap gap-2 mb-8">
+        <% @task.tags.each do |tag| %>
+          <span class="badge badge-primary">#<%= tag.name %></span>
+        <% end %>
+      </div>
+    <% end %>
+
+    
+    <div class="flex flex-col gap-2" data-controller="todo-toggle">
+      <% @task.todos.each do |todo| %>
+        <%= render "todos/todo", todo: todo %>
+      <% end %>
+    </div>
+  </div>
+
+  
+  <div class="flex flex-col justify-between gap-8 h-full">
+    
+    <%= link_to edit_task_path(@task), class: "btn btn-primary" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+      </svg>
+      編集
+    <% end %>
+
+    
+    <%= link_to "#", class: "btn btn-secondary" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+      完了
+    <% end %>
+  </div>
+</div> 
+-->

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -16,12 +16,9 @@
       <% end %>
 
       <!-- タスクのTodoリスト -->
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2" data-controller="todo-toggle">
         <% @task.todos.each do |todo| %>
-          <div class="flex items-center gap-2">
-            <input type="checkbox" class="checkbox" <%= todo.done? ? "checked" : "" %>>
-            <%= todo.body %>
-          </div>
+          <%= render "todos/todo", todo: todo %>
         <% end %>
       </div>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,30 +1,13 @@
 <div class="bg-white rounded-lg shadow-lg p-6 relative m-10">
-  <div class="flex justify-between items-center">
-    <!-- タイトル -->
-    <div class="flex flex-col">
+  <!-- 🐛 タスク項目カードの内容をパーシャルに移したが、二重でtodoリストが表示されるバグが発生しており、hotwireのturbo_frameが影響を及ぼしている可能性が高い -->
+  <%#= render "tasks/task_content" %>
+  <!-- タイトル -->
+  <div class="flex flex-col gap-4">
+    <div class="flex justify-between">
       <p class="text-2xl font-bold mb-6">
         <%= @task.title %>
       </p>
 
-      <!-- タグ -->
-      <% if @task.tags.any? %>
-        <div class="flex flex-wrap gap-2 mb-8">
-          <% @task.tags.each do |tag| %>
-            <span class="badge badge-primary">#<%= tag.name %></span>
-          <% end %>
-        </div>
-      <% end %>
-
-      <!-- タスクのTodoリスト -->
-      <div class="flex flex-col gap-2" data-controller="todo-toggle">
-        <% @task.todos.each do |todo| %>
-          <%= render "todos/todo", todo: todo %>
-        <% end %>
-      </div>
-    </div>
-
-    <!-- ボタン群 -->
-    <div class="flex flex-col">
       <!-- 編集ボタン -->
       <%= link_to edit_task_path(@task), class: "btn btn-primary" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
@@ -32,14 +15,33 @@
         </svg>
         編集
       <% end %>
+    </div>
 
+    <!-- タグ -->
+    <% if @task.tags.any? %>
+      <div class="flex flex-wrap gap-2 mb-8">
+        <% @task.tags.each do |tag| %>
+          <span class="badge badge-primary">#<%= tag.name %></span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <!-- タスクのTodoリスト -->
+    <div class="flex justify-between">
+      <div class="flex flex-col gap-2" data-controller="todo-toggle">
+        <% @task.todos.each do |todo| %>
+          <%= render "todos/todo", todo: todo %>
+        <% end %>
+      </div>
       <!-- 完了ボタン -->
-      <%= link_to "#", class: "btn btn-secondary" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-        </svg>
-        完了
-      <% end %>
+      <div class="flex flex-col justify-end">
+        <%= link_to "#", class: "btn btn-secondary" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          </svg>
+          完了
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag todo do %>
+  <%= form_with model: [todo.task, todo], local: false, class: "flex items-center gap-2" do |f| %>
+    <%= f.check_box :done, 
+        class: "checkbox", 
+        checked: todo.done?,
+        data: { action: "change->todo-toggle#toggle" } %>
+    <span class="<%= todo.done? ? 'line-through text-gray-500' : '' %>">
+      <%= todo.body %>
+    </span>
+  <% end %>
+<% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
     post "/users/guest", to: "users/sessions#create_guest", as: :guest_session
   end
 
-  resources :tasks
+  resources :tasks do
+    resources :todos, only: [:update]
+  end
 
   root "static_pages#top"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
 
   resources :tasks do
-    resources :todos, only: [:update]
+    resources :todos, only: [ :update ]
   end
 
   root "static_pages#top"


### PR DESCRIPTION
## 概要
- #65 

タスク詳細画面のTodoリストの各項目をチェックするとtodo.doneがトグルする機能を追加した。
また、画面中のタスク項目カードのレイアウトを修正し、ボタン群の間隔を適切な位置に広げた。

### Todoリストのトグル機能を追加
`app/views/tasks/show.html.erb`
`app/views/todos/_todo.html.erb`
<img width="1440" height="900" alt="スクリーンショット 2025-07-23 12 00 58" src="https://github.com/user-attachments/assets/2e30716c-e2b7-4977-9be7-04c15ac69400" />

- ✅がない状態でチェックボックスをクリックすると、紐づいているtodoレコードのdoneカラムをtrueにして、部分更新が行われる。
- ✅がある状態でチェックボックスをクリックすると、紐づいているtodoレコードのdoneカラムをfalseにして、部分更新が行われる。
- 部分更新についてはhotwireを使用した

### タスク項目カードのレイアウトを修正
`app/views/tasks/show.html.erb`
<img width="1440" height="900" alt="スクリーンショット 2025-07-23 11 58 26" src="https://github.com/user-attachments/assets/f4127635-c474-4008-b3bd-6243f00df346" />
- 「編集ボタン」と「完了ボタン」の間を適切な間隔に広げた。
