### PR TITLE
【タスク詳細画面】スレッド形式の投稿機能

### DIFF
--- a/app/models/concerns/postable.rb
+++ b/app/models/concerns/postable.rb
@@ -1,0 +1,9 @@
+module Postable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :post, as: :postable, dependent: :destroy
+    has_one :task, through: :post
+    has_one :user, through: :post
+  end
+end 

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,0 +1,2 @@
+class Memo < ApplicationRecord
+end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,2 +1,5 @@
 class Memo < ApplicationRecord
+  include Postable
+  
+  validates :body, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+  belongs_to :task
+  belongs_to :user
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :task
   belongs_to :user
+  delegate_type :postable, types: %w[Memo], dependent: :destroy
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :task
   belongs_to :user
-  delegate_type :postable, types: %w[Memo], dependent: :destroy
+  delegated_type :postable, types: %w[Memo], dependent: :destroy
 end

--- a/db/migrate/20250723052934_create_posts.rb
+++ b/db/migrate/20250723052934_create_posts.rb
@@ -1,0 +1,12 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :postable_type
+      t.integer :postable_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250723053356_create_memos.rb
+++ b/db/migrate/20250723053356_create_memos.rb
@@ -1,0 +1,9 @@
+class CreateMemos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memos do |t|
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250723061729_add_not_null_constraint_to_memos_body.rb
+++ b/db/migrate/20250723061729_add_not_null_constraint_to_memos_body.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToMemosBody < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :memos, :body, false
+  end
+end

--- a/db/migrate/20250723063543_add_not_null_constraint_to_posts_postable.rb
+++ b/db/migrate/20250723063543_add_not_null_constraint_to_posts_postable.rb
@@ -1,0 +1,6 @@
+class AddNotNullConstraintToPostsPostable < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :postable_type, false
+    change_column_null :posts, :postable_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_23_061729) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_23_063543) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,8 +23,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_23_061729) do
   create_table "posts", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
-    t.string "postable_type"
-    t.integer "postable_id"
+    t.string "postable_type", null: false
+    t.integer "postable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["task_id"], name: "index_posts_on_task_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_17_081334) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_23_052934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "user_id", null: false
+    t.string "postable_type"
+    t.integer "postable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_posts_on_task_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "tags", force: :cascade do |t|
     t.string "name"
@@ -60,6 +71,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_17_081334) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "tasks"
+  add_foreign_key "posts", "users"
   add_foreign_key "tasks", "users"
   add_foreign_key "tasktags", "tags"
   add_foreign_key "tasktags", "tasks"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_23_052934) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_23_053356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "memos", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "task_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_23_053356) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_23_061729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "memos", force: :cascade do |t|
-    t.text "body"
+    t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/memos.rb
+++ b/spec/factories/memos.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :memo do
+    body { "MyText" }
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :post do
+    task { nil }
+    user { nil }
+    postable_type { "MyString" }
+    postable_id { 1 }
+  end
+end

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Memo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- #26 

タスク詳細画面において、スレッド形式の投稿機能を実装する。

## 行った変更

### 投稿に関するモデルの作成
- [x] Postモデル（親）を作成
- [x] Memoモデル（子）を作成
- [x] Postモデルで`delegated_type`を宣言
```ruby
# app/models/post.rb
class Post < ApplicationRecord
  belongs_to :task
  belongs_to :user
  delegate_type :postable, types: %w[Memo], dependent: :destroy
end
```

- [x] Postableモジュールを定義し、Memoモデルでinclude
```ruby
# app/models/concerns/postable.rb
module Postable
  extend ActiveSupport::Concern

  included do
    has_one :post, as: :postable, dependent: :destroy
    has_one :task, through: :post
    has_one :user, through: :post
  end
end 
```
```ruby
# app/models/memo.rb
class Memo < ApplicationRecord
  include Postable
  
  validates :body, presence: true
end
```
- [x] `rails db:migrate`を実行し、スキーマを更新
```ruby
# db/schema.rb
.
.
.
  create_table "memos", force: :cascade do |t|
    t.text "body", null: false
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end

  create_table "posts", force: :cascade do |t|
    t.bigint "task_id", null: false
    t.bigint "user_id", null: false
    t.string "postable_type", null: false
    t.integer "postable_id", null: false
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["task_id"], name: "index_posts_on_task_id"
    t.index ["user_id"], name: "index_posts_on_user_id"
  end
```