### PR TITLE
Feature/#75 signup page UI

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,39 +1,40 @@
-<div class="flex flex-col items-center h-full gap-10 my-10">
-  <p class="text-2xl font-bold">Sign up</p>
+<div class="bg-white rounded-lg shadow-lg px-12 py-6 relative mx-auto my-10 max-w-md">
+  <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
+    <p class="text-2xl font-bold">新規登録</p>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col gap-5" }) do |f| %>
-    <%= render "users/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-primary" %>
+      <div class="field w-full">
+        <%= f.label :name%><br />
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-primary w-full" %>
+      </div>
+
+      <div class="field w-full">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-primary w-full" %>
+      </div>
+
+      <div class="field w-full">
+        <%= f.label :password %>
+        <% if @minimum_password_length %>
+          <p class="text-sm text-gray-500"><%= @minimum_password_length %> characters minimum</p>
+        <% end %>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-primary w-full" %>
+      </div>
+
+      <div class="field w-full">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-primary w-full" %>
+      </div>
+
+      <div class="actions flex justify-center w-full">
+        <%= f.submit "新規登録", class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+
+    <div class="flex justify-center gap-10">
+      <%= link_to "すでにアカウントをお持ちですか？ - ログイン", new_session_path(resource_name), class: "text-xs font-semibold underline" %>
     </div>
-
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autocomplete: "email", class: "input input-primary" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-        <p class="text-sm text-gray-500"><%= @minimum_password_length %> characters minimum</p>
-      <% end %>
-      <br />
-      <%= f.password_field :password, autocomplete: "new-password", class: "input input-primary" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-primary" %>
-    </div>
-
-    <div class="actions flex justify-center">
-      <%= f.submit "Sign up", class: "btn btn-primary" %>
-    </div>
-  <% end %>
-
-  <div class="flex justify-center gap-10">
-    <%= link_to "Log in", new_session_path(resource_name) %>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -21,12 +21,12 @@
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
       <div class="field w-full">
         <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-primary w-full" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-primary w-full" %>
       </div>
 
       <div class="field w-full">
         <%= f.label :password %><br />
-        <%= f.password_field :password, autocomplete: "current-password", class: "input input-primary w-full" %>
+        <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-primary w-full" %>
       </div>
 
       <% if devise_mapping.rememberable? %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
   helpers:
     label:
       user:
+        name: "名前"
         email: "メールアドレス"
         password: "パスワード"
+        password_confirmation: "パスワード（確認）"
         remember_me: "ログイン情報を記憶する"


### PR DESCRIPTION
## 概要
- #75 

画面遷移図を元に、新規登録画面のUIを改善した。また、ログイン画面の入力フォームにplaceholderを追加した。

### 画面遷移図
https://www.figma.com/design/zOplZlur07IL8oWRqlQmOy/%E3%82%BF%E3%82%B9%E3%82%AF%E3%83%A1%E3%83%A2%E3%82%A2%E3%83%97%E3%83%AA?node-id=0-1&t=ZHPxVHTtRp5Jc5Th-1

### 新規登録画面
<img width="1245" height="767" alt="Image" src="https://github.com/user-attachments/assets/64438379-325e-4b35-964a-ab17657ef3f2" />

## 実装
- [x] 画面遷移図を元に、新規登録画面のUIを改善
- [x] ログイン画面の入力フォームにplaceholderを追加

### 新規登録画面
- 画面遷移図を元に、新規登録画面のUIを改善
<img width="2828" height="1571" alt="image" src="https://github.com/user-attachments/assets/00f75c9e-214c-4425-9f1a-f0fc2c350278" />

### ログイン画面
- ログイン画面の入力フォームにplaceholderを追加
<img width="2833" height="1645" alt="image" src="https://github.com/user-attachments/assets/11921ee2-5446-49d1-aa25-a6819017cc11" />
