### PR TITLE
UI/#80 post index UI

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,13 +1,13 @@
-<div class="border-l-4 border-blue-500 pl-4 py-2">
-  <div class="flex items-center gap-2 mb-2">
+<div class="chat chat-start">
+  <div class="chat-header">
     <span class="text-sm font-medium text-gray-700">
-      <%= post.user.name || "ゲストユーザー" %>
+      <%= post.user.name %>
     </span>
-    <span class="text-xs text-gray-500">
+    <span class="text-xs text-gray-500 ml-2">
       <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
     </span>
   </div>
-  <div class="text-gray-800">
+  <div class="chat-bubble chat-bubble-primary">
     <%= post.postable.body %>
   </div>
 </div> 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -42,11 +42,10 @@
 </div>
 
 <!-- 投稿一覧 -->
-<div class="bg-white rounded-lg shadow-lg p-6 m-10">
+<div class="p-6 m-10">
   <% if @posts.any? %>
-    <h3 class="text-lg font-semibold mb-4">投稿一覧</h3>
     <div class="space-y-4">
-      <%= render partial: "posts/post", collection: @posts %>
+      <%= render @posts %>
     </div>
   <% else %>
     <div class="text-center py-8 text-gray-500">
@@ -57,12 +56,11 @@
 
 <!-- 投稿フォーム -->
 <div class="bg-white rounded-lg shadow-lg p-6 m-10">
-  <h3 class="text-lg font-semibold mb-4">ポストを投稿</h3>
   <%= render 'posts/form', task: @task, post: @post %>
 </div>
 
 <!-- 戻るボタン -->
-<div class="mt-6 text-center">
+<div class="my-6 text-center">
   <%= link_to tasks_path, class: "btn btn-primary" do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -45,7 +45,8 @@
 <div class="p-6 m-10">
   <% if @posts.any? %>
     <div class="space-y-4">
-      <%= render @posts %>
+      <%#= render @posts の記述では、scan_rubyのエラーが発生するため、以下のようにパーシャルは明示的に指定 %> 
+      <%= render partial: "posts/post", collection: @posts %>
     </div>
   <% else %>
     <div class="text-center py-8 text-gray-500">


### PR DESCRIPTION
## 概要
- #80

https://v4.daisyui.com/components/chat/
ポスト詳細画面のポスト一覧で、daisyUIのChat bubbleを使いポストを吹き出しのように表示した。

## 実装
- [x] ポストのUIをdaisyUIのChat bubbleにより吹き出し表示

### UI
#### タスク詳細画面（ポストなし）
<img width="1440" height="900" alt="スクリーンショット 2025-07-31 15 22 16" src="https://github.com/user-attachments/assets/234ae379-0827-4f26-b666-410eeedf6c37" />

#### タスク詳細画面（ポストあり）
<img width="1440" height="900" alt="スクリーンショット 2025-07-31 15 22 28" src="https://github.com/user-attachments/assets/c1a52dba-dbde-4926-bb66-b3ff6a962fb0" />
