### PR TITLE
【ヘッダー・トップ画面】配色を追加し、画面全体の色合いを調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,12 +22,12 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
+  <body class="bg-custom-cream">
     <div class="min-h-screen flex flex-col">
       <%= render 'shared/header' %>
       
       <% if Rails.env.development? %>
-        <%= render 'shared/debug_user_info' %>
+        <%#= render 'shared/debug_user_info' %>
       <% end %>
       
       <main class="w-full flex-1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,21 +27,7 @@
       <%= render 'shared/header' %>
       
       <% if Rails.env.development? %>
-        <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
-          <div class="flex">
-            <div class="ml-3">
-              <h3 class="text-sm font-medium">開発用デバッグ情報</h3>
-              <div class="mt-2 text-sm">
-                <p><strong>session[:guest_user_id]:</strong> <%= session[:guest_user_id] %></p>
-                <p><strong>ユーザーID:</strong> <%= current_or_guest_user.id %></p>
-                <p><strong>ユーザー名:</strong> <%= current_or_guest_user.name %></p>
-                <p><strong>メールアドレス:</strong> <%= current_or_guest_user.email %></p>
-                
-                <p><strong>作成日時:</strong> <%= current_or_guest_user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
-              </div>
-            </div>
-          </div>
-        </div>
+        <%= render 'shared/debug_user_info' %>
       <% end %>
       
       <main class="w-full flex-1">

--- a/app/views/shared/_debug_user_info.html.erb
+++ b/app/views/shared/_debug_user_info.html.erb
@@ -1,0 +1,15 @@
+<div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
+  <div class="flex">
+    <div class="ml-3">
+      <h3 class="text-sm font-medium">開発用デバッグ情報</h3>
+      <div class="mt-2 text-sm">
+        <p><strong>session[:guest_user_id]:</strong> <%= session[:guest_user_id] %></p>
+        <p><strong>ユーザーID:</strong> <%= current_or_guest_user.id %></p>
+        <p><strong>ユーザー名:</strong> <%= current_or_guest_user.name %></p>
+        <p><strong>メールアドレス:</strong> <%= current_or_guest_user.email %></p>
+        
+        <p><strong>作成日時:</strong> <%= current_or_guest_user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+      </div>
+    </div>
+  </div>
+</div> 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,8 @@
 <header class="bg-slate-200">
   <div class="flex justify-between items-center p-4 gap-10">
-    <%= image_tag "logo.png", class: "flex-none size-16" %>
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", class: "flex-none size-16" %>
+    <% end %>
     <% if !auth_page? %>
       <div class="flex-1 flex justify-start items-center gap-10">
         <%= link_to "タスクをみる", tasks_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,8 +6,9 @@
     <% if !auth_page? %>
       <div class="flex-1 flex justify-start items-center gap-10">
         <%= link_to "タスクをみる", tasks_path %>
-        <%= link_to "マイリスト", "#" %>
-        <%= link_to "さがす", "#" %>
+        <!-- マイリスト画面とさがす画面はまだ実装していないので、クリックしたらアラートが表示されるようにしている。 -->
+        <%= link_to "マイリスト", "#", onclick: "alert('Coming soon!'); return false;" %>
+        <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;" %>
       </div>
       <% if user_signed_in? %>
         <%= link_to "ログアウト", destroy_user_session_path, class: "flex-none btn btn-secondary", data: { turbo_method: :delete } %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,19 +1,19 @@
-<header class="bg-slate-200">
+<header class="bg-custom-brown">
   <div class="flex justify-between items-center p-4 gap-10">
     <%= link_to root_path do %>
       <%= image_tag "logo.png", class: "flex-none size-16" %>
     <% end %>
     <% if !auth_page? %>
       <div class="flex-1 flex justify-start items-center gap-10">
-        <%= link_to "タスクをみる", tasks_path %>
+        <%= link_to "タスクをみる", tasks_path, class: "text-custom-cream hover:text-custom-cream transition-colors" %>
         <!-- マイリスト画面とさがす画面はまだ実装していないので、クリックしたらアラートが表示されるようにしている。 -->
-        <%= link_to "マイリスト", "#", onclick: "alert('Coming soon!'); return false;" %>
-        <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;" %>
+        <%= link_to "マイリスト", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-cream hover:text-custom-cream transition-colors" %>
+        <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-cream hover:text-custom-cream transition-colors" %>
       </div>
       <% if user_signed_in? %>
-        <%= link_to "ログアウト", destroy_user_session_path, class: "flex-none btn btn-secondary", data: { turbo_method: :delete } %>
+        <%= link_to "ログアウト", destroy_user_session_path, class: "flex-none btn bg-custom-sage-dark border-custom-sage-dark hover:bg-custom-sage hover:border-custom-sage text-custom-cream", data: { turbo_method: :delete } %>
       <% else %>
-        <%= link_to "ログイン", new_user_session_path, class: "flex-none btn btn-primary" %>
+        <%= link_to "ログイン", new_user_session_path, class: "flex-none btn bg-custom-sage-dark border-custom-sage-dark hover:bg-custom-sage hover:border-custom-sage text-custom-cream" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,15 +1,15 @@
-<div class="flex flex-col items-center h-full gap-10 my-10">
+<div class="flex flex-col items-center h-full gap-10 my-10 bg-custom-cream min-h-screen">
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-slate-200 w-60 h-60 rounded-lg"></div>
-    <div class="bg-slate-400 w-60 h-60 rounded-lg"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
   </div>
-  <%= link_to "タスクをみる", tasks_path, class: "btn btn-primary" %>
+  <%= link_to "タスクをみる", tasks_path, class: "btn bg-custom-sage-dark border-custom-sage-dark hover:bg-custom-sage hover:border-custom-sage text-custom-cream" %>
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-slate-400 w-60 h-60 rounded-lg"></div>
-    <div class="bg-slate-200 w-60 h-60 rounded-lg"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
   </div>
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-slate-200 w-60 h-60 rounded-lg"></div>
-    <div class="bg-slate-400 w-60 h-60 rounded-lg"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
   </div>
 </div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,16 +1,25 @@
-const defaultTheme = require('tailwindcss/defaultTheme')
+const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
   content: [
-    './public/*.html',
-    './app/helpers/**/*.rb',
-    './app/javascript/**/*.js',
-    './app/views/**/*.{erb,haml,html,slim}'
+    "./public/*.html",
+    "./app/helpers/**/*.rb",
+    "./app/javascript/**/*.js",
+    "./app/views/**/*.{erb,haml,html,slim}",
   ],
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+        sans: ["Inter var", ...defaultTheme.fontFamily.sans],
+      },
+      colors: {
+        custom: {
+          cream: "#FFF8E8",
+          beige: "#F7EED3",
+          sage: "#AAB396",
+          "sage-dark": "#8A9A7A",
+          brown: "#674636",
+        },
       },
     },
   },
@@ -18,5 +27,5 @@ module.exports = {
     // require('@tailwindcss/forms'),
     // require('@tailwindcss/typography'),
     // require('@tailwindcss/container-queries'),
-  ]
-}
+  ],
+};


### PR DESCRIPTION
## 概要
- #66 
- #68 

ヘッダー・トップ画面に配色を追加し、画面全体の色合いを調整した。

## 実装
### ヘッダー
- [x] 配色
- [x] ロゴからトップ画面への遷移を追加
- [x] 未実装画面へ繋がるリンクをクリックすると、アラートが表示されるようにする。

### トップ画面
- [x] 配色
<img width="1440" height="900" alt="スクリーンショット 2025-08-01 14 54 29" src="https://github.com/user-attachments/assets/fcdcc025-a3d3-4b61-9317-140126ec4dd0" />
