### PR TITLE
【ログイン・新規登録画面】配色しUIを修正

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -8,12 +8,12 @@
 
         <div class="field w-full">
           <%= f.label :name, class: "text-custom-brown font-medium" %><br />
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <div class="field w-full">
           <%= f.label :email, class: "text-custom-brown font-medium" %><br />
-          <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <div class="field w-full">
@@ -21,12 +21,12 @@
           <% if @minimum_password_length %>
             <p class="text-sm text-custom-brown/60"><%= @minimum_password_length %> characters minimum</p>
           <% end %>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <div class="field w-full">
           <%= f.label :password_confirmation, class: "text-custom-brown font-medium" %><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <div class="actions flex justify-center w-full">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,40 +1,42 @@
-<div class="bg-white rounded-lg shadow-lg px-12 py-6 relative mx-auto my-10 max-w-md">
-  <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
-    <p class="text-2xl font-bold">新規登録</p>
+<div class="bg-custom-cream flex items-center justify-center py-10">
+  <div class="bg-custom-beige rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-brown/20">
+    <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
+      <p class="text-2xl font-bold text-custom-brown">新規登録</p>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
 
-      <div class="field w-full">
-        <%= f.label :name%><br />
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-primary w-full" %>
+        <div class="field w-full">
+          <%= f.label :name, class: "text-custom-brown font-medium" %><br />
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <div class="field w-full">
+          <%= f.label :email, class: "text-custom-brown font-medium" %><br />
+          <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <div class="field w-full">
+          <%= f.label :password, class: "text-custom-brown font-medium" %>
+          <% if @minimum_password_length %>
+            <p class="text-sm text-custom-brown/60"><%= @minimum_password_length %> characters minimum</p>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <div class="field w-full">
+          <%= f.label :password_confirmation, class: "text-custom-brown font-medium" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <div class="actions flex justify-center w-full">
+          <%= f.submit "新規登録", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full" %>
+        </div>
+      <% end %>
+
+      <div class="flex justify-center gap-10">
+        <%= link_to "すでにアカウントをお持ちですか？ - ログイン", new_session_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
       </div>
-
-      <div class="field w-full">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-primary w-full" %>
-      </div>
-
-      <div class="field w-full">
-        <%= f.label :password %>
-        <% if @minimum_password_length %>
-          <p class="text-sm text-gray-500"><%= @minimum_password_length %> characters minimum</p>
-        <% end %>
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-primary w-full" %>
-      </div>
-
-      <div class="field w-full">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-primary w-full" %>
-      </div>
-
-      <div class="actions flex justify-center w-full">
-        <%= f.submit "新規登録", class: "btn btn-primary w-full" %>
-      </div>
-    <% end %>
-
-    <div class="flex justify-center gap-10">
-      <%= link_to "すでにアカウントをお持ちですか？ - ログイン", new_session_path(resource_name), class: "text-xs font-semibold underline" %>
     </div>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,49 +1,51 @@
-<div class="bg-white rounded-lg shadow-lg px-12 py-6 relative mx-auto my-10 max-w-md">
-  <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
-    <p class="text-2xl font-bold">ログイン</p>
+<div class="bg-custom-cream flex items-center justify-center py-10">
+  <div class="bg-custom-beige rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-brown/20">
+    <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
+      <p class="text-2xl font-bold text-custom-brown">ログイン</p>
 
-    <%= form_with url: guest_session_path, method: :post, html: { class: "w-full" } do |f| %>
-      <button type="submit" class="btn btn-primary w-full">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
-          <path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd" />
-        </svg>
-        ゲストとしてアクセス
-      </button>
-    <% end %>
+      <%= form_with url: guest_session_path, method: :post, html: { class: "w-full" } do |f| %>
+        <button type="submit" class="btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+            <path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd" />
+          </svg>
+          ゲストとしてアクセス
+        </button>
+      <% end %>
 
-    <!-- 区切り線 -->
-    <div class="flex items-center w-full">
-      <div class="flex-1 border-t border-gray-300"></div>
-      <span class="px-4 text-sm text-gray-500">または</span>
-      <div class="flex-1 border-t border-gray-300"></div>
-    </div>
-    
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
-      <div class="field w-full">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-primary w-full" %>
+      <!-- 区切り線 -->
+      <div class="flex items-center w-full">
+        <div class="flex-1 border-t border-custom-brown/30"></div>
+        <span class="px-4 text-sm text-custom-brown/60">または</span>
+        <div class="flex-1 border-t border-custom-brown/30"></div>
       </div>
-
-      <div class="field w-full">
-        <%= f.label :password %><br />
-        <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-primary w-full" %>
-      </div>
-
-      <% if devise_mapping.rememberable? %>
+      
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
         <div class="field w-full">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me %>
+          <%= f.label :email, class: "text-custom-brown font-medium" %><br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <div class="field w-full">
+          <%= f.label :password, class: "text-custom-brown font-medium" %><br />
+          <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="field w-full">
+            <%= f.check_box :remember_me, class: "checkbox bg-custom-cream border-custom-brown" %>
+            <%= f.label :remember_me, class: "text-custom-brown ml-2" %>
+          </div>
+        <% end %>
+
+        <div class="actions flex justify-center w-full">
+          <%= f.submit "ログイン", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full" %>
         </div>
       <% end %>
 
-      <div class="actions flex justify-center w-full">
-        <%= f.submit "ログイン", class: "btn btn-primary w-full" %>
+      <div class="flex justify-center gap-10">
+        <%= link_to "新規アカウントを作成", new_registration_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
+        <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
       </div>
-    <% end %>
-
-    <div class="flex justify-center gap-10">
-      <%= link_to "新規アカウントを作成", new_registration_path(resource_name), class: "text-xs font-semibold underline" %>
-      <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "text-xs font-semibold underline" %>
     </div>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -22,18 +22,20 @@
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
         <div class="field w-full">
           <%= f.label :email, class: "text-custom-brown font-medium" %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <div class="field w-full">
           <%= f.label :password, class: "text-custom-brown font-medium" %><br />
-          <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+          <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
-          <div class="field w-full">
-            <%= f.check_box :remember_me, class: "checkbox bg-custom-cream border-custom-brown" %>
-            <%= f.label :remember_me, class: "text-custom-brown ml-2" %>
+          <div class="form-control w-full">
+            <label class="label cursor-pointer">
+              <%= f.check_box :remember_me, class: "checkbox bg-custom-cream border-custom-brown", style: "--chkbg: #674636; --chkfg: #FFF8E8;" %>
+              <span class="label-text text-custom-brown">ログイン状態を保持</span>
+            </label>
           </div>
         <% end %>
 


### PR DESCRIPTION
## 概要
- #66 
- #93

ログイン・新規登録画面を配色しUIを修正した。

## 実装

### ログイン画面

<img width="1440" height="900" alt="Image" src="https://github.com/user-attachments/assets/2a9199b9-df06-4a38-bfad-8c1555d5be42" />

### 新規登録画面

<img width="1440" height="900" alt="Image" src="https://github.com/user-attachments/assets/1926d86f-8eda-4361-91c9-807649dc24f7" />