### PR TITLE
Feature/#61 task tag limit

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,4 +14,13 @@ class Task < ApplicationRecord
 
   validates :title, presence: true, length: { minimum: 2, maximum: 255 }
   validates :status, presence: true
+  validate :tags_must_be_five_or_less
+
+  private
+
+  def tags_must_be_five_or_less
+    if tag_ids.present? && tag_ids.length > 5
+      errors.add(:tag_ids, "は最大5個まで選択できます")
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -20,7 +20,7 @@ class Task < ApplicationRecord
 
   def tags_must_be_five_or_less
     if tag_ids.present? && tag_ids.length > 5
-      errors.add(:tag_ids, "は最大5個まで選択できます")
+      errors.add(:tag_ids, :too_many)
     end
   end
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,20 @@
+<% if object.errors.any? %>
+  <div class="alert bg-custom-cream border border-custom-brown text-custom-brown mb-4">
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.0" stroke="currentColor" class="size-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+        </svg>
+        <h3 class="font-bold text-custom-brown">エラーが発生しました</h3>
+      </div>
+    
+      <div class="text-sm text-custom-brown">
+        <ul class="list-disc list-inside">
+          <% object.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+<% end %> 

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,6 +1,9 @@
 <div class="flex flex-col items-center my-10 bg-custom-cream min-h-screen">
   <div class="card bg-custom-beige shadow-xl max-w-2xl w-full border border-custom-brown/20">
     <div class="card-body">      
+      <!-- エラーメッセージ表示エリア -->
+      <%= render 'shared/error_messages', object: @task %>
+
       <%= form_with model: @task, local: true, html: { class: "flex flex-col gap-6" } do |f| %>
         <!-- タイトル入力フィールド -->
         <div class="form-control">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -3,6 +3,9 @@
     <div class="card-body">      
       <h2 class="text-3xl font-bold text-custom-brown text-center mb-6">新しいタスク</h2>
       
+      <!-- エラーメッセージ表示エリア -->
+      <%= render 'shared/error_messages', object: @task %>
+      
       <%= form_with model: @task, local: true, html: { class: "flex flex-col gap-6" } do |f| %>
         <!-- タイトル入力フィールド -->
         <div class="form-control">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,8 +1,6 @@
 <div class="flex flex-col items-center my-10 bg-custom-cream min-h-screen">
   <div class="card bg-custom-beige shadow-xl max-w-2xl w-full border border-custom-brown/20">
     <div class="card-body">      
-      <h2 class="text-3xl font-bold text-custom-brown text-center mb-6">新しいタスク</h2>
-      
       <!-- エラーメッセージ表示エリア -->
       <%= render 'shared/error_messages', object: @task %>
       

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,3 +27,6 @@ ja:
       blank: "を入力してください"
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以下で入力してください"
+    attributes:
+      tag_ids:
+        too_many: "は最大5個まで選択できます"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,17 @@ ja:
         title: "タイトル"
         tag_ids: "タグ"
         todos: "やることリスト"
+
+  # エラーメッセージの和訳
+  errors:
+    messages:
+      blank: "を入力してください"
+      too_short: "は%{count}文字以上で入力してください"
+      too_long: "は%{count}文字以下で入力してください"
+    attributes:
+      title:
+        blank: "タイトルを入力してください"
+        too_short: "タイトルは%{count}文字以上で入力してください"
+        too_long: "タイトルは%{count}文字以下で入力してください"
+      status:
+        blank: "ステータスを選択してください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,16 +13,17 @@ ja:
         tag_ids: "タグ"
         todos: "やることリスト"
 
+  # ActiveRecordの属性名翻訳
+  activerecord:
+    attributes:
+      task:
+        title: "タイトル"
+        tag_ids: "タグ"
+        status: "ステータス"
+
   # エラーメッセージの和訳
   errors:
     messages:
       blank: "を入力してください"
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以下で入力してください"
-    attributes:
-      title:
-        blank: "タイトルを入力してください"
-        too_short: "タイトルは%{count}文字以上で入力してください"
-        too_long: "タイトルは%{count}文字以下で入力してください"
-      status:
-        blank: "ステータスを選択してください"

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -32,4 +32,41 @@ RSpec.describe Task, type: :model do
       expect(task_with_long_title.errors[:title]).to include('is too long (maximum is 255 characters)')
     end
   end
+
+  describe 'タグの個数制限バリデーション' do
+    let(:user) { create(:user) }
+    let(:tags) { create_list(:tag, 6) }
+
+    it 'タグが5個以下の場合は有効' do
+      task = build(:task, user: user, tag_ids: tags.first(5).map(&:id))
+      expect(task).to be_valid
+      expect(task.errors[:tag_ids]).to be_empty
+    end
+
+    it 'タグが6個の場合は無効' do
+      task = build(:task, user: user, tag_ids: tags.map(&:id))
+      expect(task).to be_invalid
+      expect(task.errors[:tag_ids]).to include('は最大5個まで選択できます')
+    end
+
+    it 'タグが選択されていない場合は有効' do
+      task = build(:task, user: user, tag_ids: [])
+      expect(task).to be_valid
+      expect(task.errors[:tag_ids]).to be_empty
+    end
+
+    it 'タグが選択されていない場合（nil）は有効' do
+      task = build(:task, user: user, tag_ids: nil)
+      expect(task).to be_valid
+      expect(task.errors[:tag_ids]).to be_empty
+    end
+
+    it 'タグが7個の場合は無効' do
+      extra_tags = create_list(:tag, 1)
+      all_tags = tags + extra_tags
+      task = build(:task, user: user, tag_ids: all_tags.map(&:id))
+      expect(task).to be_invalid
+      expect(task.errors[:tag_ids]).to include('は最大5個まで選択できます')
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe Task, type: :model do
     it 'titleがない場合、バリデーションが機能し、invalidになる' do
       task_without_title = build(:task, title: nil)
       expect(task_without_title).to be_invalid
-      expect(task_without_title.errors[:title]).to include("can't be blank")
+      expect(task_without_title.errors[:title]).to include("タイトルを入力してください")
     end
 
     it 'statusがない場合、バリデーションが機能し、invalidになる' do
       task_without_status = build(:task, status: nil)
       expect(task_without_status).to be_invalid
-      expect(task_without_status.errors[:status]).to include("can't be blank")
+      expect(task_without_status.errors[:status]).to include("ステータスを選択してください")
     end
 
     it 'titleが1文字の場合、バリデーションが機能し、invalidになる' do
       task_with_short_title = build(:task, title: 'A')
       expect(task_with_short_title).to be_invalid
-      expect(task_with_short_title.errors[:title]).to include('is too short (minimum is 2 characters)')
+      expect(task_with_short_title.errors[:title]).to include('タイトルは2文字以上で入力してください')
     end
 
     it 'titleが256文字の場合、バリデーションが機能し、invalidになる' do
       task_with_long_title = build(:task, title: 'A' * 256)
       expect(task_with_long_title).to be_invalid
-      expect(task_with_long_title.errors[:title]).to include('is too long (maximum is 255 characters)')
+      expect(task_with_long_title.errors[:title]).to include('タイトルは255文字以下で入力してください')
     end
   end
 
@@ -37,36 +37,36 @@ RSpec.describe Task, type: :model do
     let(:user) { create(:user) }
     let(:tags) { create_list(:tag, 6) }
 
-    it 'タグが5個以下の場合は有効' do
-      task = build(:task, user: user, tag_ids: tags.first(5).map(&:id))
-      expect(task).to be_valid
-      expect(task.errors[:tag_ids]).to be_empty
+    it 'タグが5個以下の場合、validになる' do
+      task_with_five_tags = build(:task, user: user, tag_ids: tags.first(5).map(&:id))
+      expect(task_with_five_tags).to be_valid
+      expect(task_with_five_tags.errors[:tag_ids]).to be_empty
     end
 
-    it 'タグが6個の場合は無効' do
-      task = build(:task, user: user, tag_ids: tags.map(&:id))
-      expect(task).to be_invalid
-      expect(task.errors[:tag_ids]).to include('は最大5個まで選択できます')
+    it 'タグが6個の場合、invalidになる' do
+      task_with_six_tags = build(:task, user: user, tag_ids: tags.map(&:id))
+      expect(task_with_six_tags).to be_invalid
+      expect(task_with_six_tags.errors[:tag_ids]).to include('は最大5個まで選択できます')
     end
 
-    it 'タグが選択されていない場合は有効' do
-      task = build(:task, user: user, tag_ids: [])
-      expect(task).to be_valid
-      expect(task.errors[:tag_ids]).to be_empty
+    it 'タグが選択されていない場合、validになる' do
+      task_without_tags = build(:task, user: user, tag_ids: [])
+      expect(task_without_tags).to be_valid
+      expect(task_without_tags.errors[:tag_ids]).to be_empty
     end
 
-    it 'タグが選択されていない場合（nil）は有効' do
-      task = build(:task, user: user, tag_ids: nil)
-      expect(task).to be_valid
-      expect(task.errors[:tag_ids]).to be_empty
+    it 'タグが選択されていない場合（nil）、validになる' do
+      task_with_nil_tags = build(:task, user: user, tag_ids: nil)
+      expect(task_with_nil_tags).to be_valid
+      expect(task_with_nil_tags.errors[:tag_ids]).to be_empty
     end
 
-    it 'タグが7個の場合は無効' do
+    it 'タグが7個の場合、invalidになる' do
       extra_tags = create_list(:tag, 1)
       all_tags = tags + extra_tags
-      task = build(:task, user: user, tag_ids: all_tags.map(&:id))
-      expect(task).to be_invalid
-      expect(task.errors[:tag_ids]).to include('は最大5個まで選択できます')
+      task_with_seven_tags = build(:task, user: user, tag_ids: all_tags.map(&:id))
+      expect(task_with_seven_tags).to be_invalid
+      expect(task_with_seven_tags.errors[:tag_ids]).to include('は最大5個まで選択できます')
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -11,25 +11,24 @@ RSpec.describe Task, type: :model do
     it 'titleがない場合、バリデーションが機能し、invalidになる' do
       task_without_title = build(:task, title: nil)
       expect(task_without_title).to be_invalid
-      expect(task_without_title.errors[:title]).to include("タイトルを入力してください")
+      expect(task_without_title.errors[:title]).to include("を入力してください")
     end
 
     it 'statusがない場合、バリデーションが機能し、invalidになる' do
       task_without_status = build(:task, status: nil)
       expect(task_without_status).to be_invalid
-      expect(task_without_status.errors[:status]).to include("ステータスを選択してください")
     end
 
     it 'titleが1文字の場合、バリデーションが機能し、invalidになる' do
       task_with_short_title = build(:task, title: 'A')
       expect(task_with_short_title).to be_invalid
-      expect(task_with_short_title.errors[:title]).to include('タイトルは2文字以上で入力してください')
+      expect(task_with_short_title.errors[:title]).to include('は2文字以上で入力してください')
     end
 
     it 'titleが256文字の場合、バリデーションが機能し、invalidになる' do
       task_with_long_title = build(:task, title: 'A' * 256)
       expect(task_with_long_title).to be_invalid
-      expect(task_with_long_title.errors[:title]).to include('タイトルは255文字以下で入力してください')
+      expect(task_with_long_title.errors[:title]).to include('は255文字以下で入力してください')
     end
   end
 


### PR DESCRIPTION
## 概要
- #61 

タスクモデルに紐づくタグの個数を最大5個に制限するバリデーションを追加した。
また、タスク新規作成画面・編集画面にエラーメッセージパーシャルを追加し、タグを6個以上選ぶと、エラーメッセージを表示するようにした。
さらに、RSpecによりタスクのモデルスペックを作成し、紐づくタグの個数制限のバリデーションチェックを行った。

## 実装
### Taskモデルに紐づくタグの個数制限のバリデーションを追加
- [x] 紐づくタグが6個以上の場合、バリデーションエラーを起こし、エラーメッセージを追加する
```ruby
  validate :tags_must_be_five_or_less
  private

  def tags_must_be_five_or_less
    if tag_ids.present? && tag_ids.length > 5
      errors.add(:tag_ids, :too_many)
    end
  end
```

### ja.ymlにエラーメッセージの翻訳を追加
```yaml
  # ActiveRecordの属性名翻訳
  activerecord:
    attributes:
      task:
        title: "タイトル"
        tag_ids: "タグ"
        status: "ステータス"
  # エラーメッセージの和訳
  errors:
    messages:
      blank: "を入力してください"
      too_short: "は%{count}文字以上で入力してください"
      too_long: "は%{count}文字以下で入力してください"
    attributes:
      tag_ids:
        too_many: "は最大5個まで選択できます"
```

### タスク新規作成画面でエラーメッセージを表示
- [x] タグを6個以上選ぶと、エラーメッセージを表示
<img width="1440" height="900" alt="スクリーンショット 2025-08-05 16 13 42" src="https://github.com/user-attachments/assets/a1547fac-b810-45d3-80b3-d41a020d3b57" />


### タスク編集画面でエラーメッセージを表示
- [x] タグを6個以上選ぶと、エラーメッセージを表示
<img width="1440" height="900" alt="スクリーンショット 2025-08-05 16 13 59" src="https://github.com/user-attachments/assets/5642c6e8-f156-4626-9e41-0572b43a0001" />


### タスクのモデルスペックで、紐づくタグの個数制限のバリデーションチェック
- タグが5個以下の場合、validになる
- タグが6個の場合、invalidになる
- タグが選択されていない場合、validになる
- タグが選択されていない場合（nil）、validになる
- タグが7個の場合、invalidになる

## 今後の実装
- タスク新規作成画面・編集画面でタグを5個選択すると他のタグを選択不可にするjsを追加
- Userモデルスペックの修正