### PR TITLE
【タスク関連画面】認証フィルターの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
       if session[:guest_user_id] && session[:guest_user_id] != current_user.id
         logging_in # データ引き継ぎの機能は今後実装しないかの性が高い
         # reload guest_user to prevent caching problems before destruction
-        # 
+        #
         # キャッシュの問題を回避: @cached_guest_userが古いオブジェクトを参照する可能性
         # 解決策: with_retry=falseでキャッシュ無視 → reloadで最新状態取得 → 安全に削除
         guest_user(with_retry = false).try(:reload).try(:destroy)
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
   # creating one as needed
   def guest_user(with_retry = true)
     # Cache the value the first time it's gotten.
-    # 
+    #
     # キャッシュ: @cached_guest_userで初回のみDBクエリ、以降はキャッシュを返す
     # 注意: 削除処理時はwith_retry=falseでキャッシュを無視する必要がある
     @cached_guest_user ||= User.find(session[:guest_user_id] ||= create_guest_user.id)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def create
-    @task = current_or_guest_user.tasks.find(params[:task_id])
-    @post = @task.posts.build(user: current_or_guest_user)
+    @task = current_user.tasks.find(params[:task_id])
+    @post = @task.posts.build(user: current_user)
 
     # TextPostを作成
     text_post = TextPost.new(post_params)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,6 @@
 class TasksController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @tasks = current_or_guest_user.tasks.includes(:tags).order(created_at: :desc)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,15 +2,15 @@ class TasksController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @tasks = current_or_guest_user.tasks.includes(:tags).order(created_at: :desc)
+    @tasks = current_user.tasks.includes(:tags).order(created_at: :desc)
   end
 
   def new
-    @task = current_or_guest_user.tasks.build
+    @task = current_user.tasks.build
   end
 
   def create
-    @task = current_or_guest_user.tasks.build(task_params)
+    @task = current_user.tasks.build(task_params)
 
     if @task.save
       redirect_to @task, notice: "タスクが正常に作成されました。"
@@ -20,17 +20,17 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = current_or_guest_user.tasks.includes(:tags, :posts).find(params[:id])
+    @task = current_user.tasks.includes(:tags, :posts).find(params[:id])
     @posts = @task.posts.includes(:user, :postable).order(created_at: :asc)
     @post = Post.new
   end
 
   def edit
-    @task = current_or_guest_user.tasks.includes(:tags, :todos).find(params[:id])
+    @task = current_user.tasks.includes(:tags, :todos).find(params[:id])
   end
 
   def update
-    @task = current_or_guest_user.tasks.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
 
     if @task.update(task_params)
       redirect_to @task, notice: "タスクが正常に更新されました。"
@@ -40,7 +40,7 @@ class TasksController < ApplicationController
   end
 
   def toggle_status
-    @task = current_or_guest_user.tasks.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
     new_status = @task.done? ? :doing : :done
 
     if @task.update(status: new_status)

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -9,6 +9,6 @@ class TodosController < ApplicationController
   private
 
   def set_todo
-    @todo = current_or_guest_user.tasks.find(params[:task_id]).todos.find(params[:id])
+    @todo = current_user.tasks.find(params[:task_id]).todos.find(params[:id])
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,9 +21,19 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    # ゲストユーザーの場合は適切に削除処理を行う
+    if current_user&.email&.start_with?('guest_')
+      # キャッシュの問題を回避: current_userはWarden戦略によりキャッシュされたオブジェクトの可能性
+      # 解決策: IDを保存 → セッションクリア → データベースから直接削除
+      guest_user_id = current_user.id
+      session[:guest_user_id] = nil
+      
+      # データベースから直接取得して削除（キャッシュを無視）
+      User.find_by(id: guest_user_id)&.destroy
+    end
+    super
+  end
 
   # protected
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -23,12 +23,12 @@ class Users::SessionsController < Devise::SessionsController
   # DELETE /resource/sign_out
   def destroy
     # ゲストユーザーの場合は適切に削除処理を行う
-    if current_user&.email&.start_with?('guest_')
+    if current_user&.email&.start_with?("guest_")
       # キャッシュの問題を回避: current_userはWarden戦略によりキャッシュされたオブジェクトの可能性
       # 解決策: IDを保存 → セッションクリア → データベースから直接削除
       guest_user_id = current_user.id
       session[:guest_user_id] = nil
-      
+
       # データベースから直接取得して削除（キャッシュを無視）
       User.find_by(id: guest_user_id)&.destroy
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   belongs_to :user
 
-  has_many :tasktags
+  has_many :tasktags, dependent: :destroy
   has_many :tags, through: :tasktags
   has_many :todos, dependent: :destroy
   has_many :posts, dependent: :destroy

--- a/app/views/shared/_debug_user_info.html.erb
+++ b/app/views/shared/_debug_user_info.html.erb
@@ -3,12 +3,13 @@
     <div class="ml-3">
       <h3 class="text-sm font-medium">開発用デバッグ情報</h3>
       <div class="mt-2 text-sm">
-        <p><strong>session[:guest_user_id]:</strong> <%= session[:guest_user_id] %></p>
-        <p><strong>ユーザーID:</strong> <%= current_or_guest_user.id %></p>
-        <p><strong>ユーザー名:</strong> <%= current_or_guest_user.name %></p>
-        <p><strong>メールアドレス:</strong> <%= current_or_guest_user.email %></p>
-        
-        <p><strong>作成日時:</strong> <%= current_or_guest_user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+        <p><strong>user_signed_in?:</strong> <%= user_signed_in? %></p>
+        <p><strong>session[:guest_user_id]:</strong> <%= session[:guest_user_id].present? ? session[:guest_user_id] : 'なし' %></p>
+
+        <p><strong>ユーザーID(current_user.id):</strong> <%= current_user.present? ? current_user.id : 'なし' %></p>
+        <p><strong>ユーザー名(current_user.name):</strong> <%= current_user.present? ? current_user.name : 'なし' %></p>
+        <p><strong>メールアドレス(current_user.email):</strong> <%= current_user.present? ? current_user.email : 'なし' %></p>
+        <p><strong>作成日時(current_user.created_at):</strong> <%= current_user.present? ? current_user.created_at.strftime('%Y-%m-%d %H:%M:%S') : 'なし' %></p>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
         <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-cream hover:text-custom-cream transition-colors" %>
       </div>
       <% if user_signed_in? %>
-        <%= link_to "ログアウト", destroy_user_session_path, class: "flex-none btn bg-custom-sage border-custom-sage hover:bg-custom-sage-light hover:border-custom-sage-light text-custom-cream", data: { turbo_method: :delete } %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "flex-none btn bg-custom-sage border-custom-sage hover:bg-custom-sage-light hover:border-custom-sage-light text-custom-cream" %>
       <% else %>
         <%= link_to "ログイン", new_user_session_path, class: "flex-none btn bg-custom-sage border-custom-sage hover:bg-custom-sage-light hover:border-custom-sage-light text-custom-cream" %>
       <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -277,10 +277,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  # 既存のwardenストラテジーにguest_userストラテジーを追加
+  config.warden do |manager|
+    manager.default_strategies(scope: :user).push :guest_user
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/initializers/guest_user_strategy.rb
+++ b/config/initializers/guest_user_strategy.rb
@@ -13,4 +13,4 @@ Warden::Strategies.add(:guest_user) do
     u = User.where(id: session[:guest_user_id]).first
     success!(u) if u.present?
   end
-end 
+end

--- a/config/initializers/guest_user_strategy.rb
+++ b/config/initializers/guest_user_strategy.rb
@@ -1,0 +1,16 @@
+# wardenストラテジーについてはこちらを参照
+# https://github.com/wardencommunity/warden/wiki/Strategies
+Warden::Strategies.add(:guest_user) do
+  # このストラテジーが実行されるべきかを判定
+  # ゲストユーザーIDがセッションに存在する場合のみ、このストラテジーが有効になる
+  def valid?
+    session[:guest_user_id].present?
+  end
+
+  # 実際の認証処理を実行
+  # ゲストユーザーIDをもとに、ユーザーを取得し、認証を行う
+  def authenticate!
+    u = User.where(id: session[:guest_user_id]).first
+    success!(u) if u.present?
+  end
+end 


### PR DESCRIPTION
## 概要
ログインしていない状態でタスク関連画面に遷移しようとした場合、認証画面にリダイレクトするように認証フィルターをかける。

### 関連するブランチ
- #85 

## 実装
### タスク関連画面に認証フィルターを追加
- deviseが提供するヘルパーメソッドをbefore_actionで定義する
```ruby
# app/controllers/tasks_controller.rb
class TasksController < ApplicationController
  before_action :authenticate_user!
```

### 認証フィルターをゲストユーザーにも適用する
https://github.com/heartcombo/devise/wiki/How-To:-Create-a-guest-user#authentication-this-may-interfere-with-the-current_user-helper

- ゲストユーザー用の認証フィルターを実装するため、Wardenストラテジーを追加
```ruby
# config/initializers/guest_user_strategy.rb
Warden::Strategies.add(:guest_user) do
  # このストラテジーが実行されるべきかを判定
  # ゲストユーザーIDがセッションに存在する場合のみ、このストラテジーが有効になる
  def valid?
    session[:guest_user_id].present?
  end

  # 実際の認証処理を実行
  # ゲストユーザーIDをもとに、ユーザーを取得し、認証を行う
  def authenticate!
    u = User.where(id: session[:guest_user_id]).first
    success!(u) if u.present?
  end
end 
```

### 既存のWardenストラテジーに上述のストラテジーを追加
```ruby
# config/initializers/devise.rb
  config.warden do |manager|
    manager.default_strategies(scope: :user).push :guest_user
  end
```
- この変更により、ゲストユーザーでログインした後、`user_signed_in?`はtrueになり、`current_user`はゲストユーザーを示す
- そのため、ゲストユーザーでログイン中の場合も、認証画面へアクセスした場合ホーム画面にリダイレクトするようになる。

### ログアウト機能の改善
- ゲストユーザーでログインしている状態からログアウトした際にゲストユーザーを適切に削除する機能を実装
```ruby
# app/controllers/users/sessions_controller.rb
  def destroy
    # ゲストユーザーの場合は適切に削除処理を行う
    if current_user&.email&.start_with?('guest_')
      # キャッシュの問題を回避: current_userはWarden戦略によりキャッシュされたオブジェクトの可能性
      # 解決策: IDを保存 → セッションクリア → データベースから直接削除
      guest_user_id = current_user.id
      session[:guest_user_id] = nil
      
      # データベースから直接取得して削除（キャッシュを無視）
      User.find_by(id: guest_user_id)&.destroy
    end
    super
  end
```

### 各コントローラーのcurrent_or_guest_userの記述をcurrent_userに統一

## 懸念時効
- ゲストユーザーでログインした場合も、ログイン中と見なすため、認証画面へアクセスすることができなくなった。そのため、ゲストユーザーから登録ユーザーへのデータの引き継ぎの実装は廃止する可能性が高い