### PR TITLE
【ヘッダー・タスク関連画面】配色とスタイルを修正し、モダンなUIに改善

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-custom-cream">
+  <body class="bg-custom-off-white p-2">
     <div class="min-h-screen flex flex-col">
       <%= render 'shared/header' %>
       
@@ -30,7 +30,7 @@
         <%#= render 'shared/debug_user_info' %>
       <% end %>
       
-      <main class="w-full flex-1">
+      <main class="w-full flex-1 pt-2">
         <%= yield %>
       </main>
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
       <%= form.fields_for :postable_attributes do |text_post_form| %>
         <%= text_post_form.text_area :body, 
             placeholder: "コメントを入力してください...", 
-            class: "textarea textarea-bordered w-full h-24 bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+            class: "textarea textarea-bordered w-full h-24 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
       <% end %>
     </div>
     <!-- ⚠️ この実装では、完了ボタンを押しても、patchリクエストのurlがtask_post_path(task)になってしまい、ルーティングエラーが発生する。
@@ -18,7 +18,7 @@
   <div class="flex justify-end gap-4">
     <%= render "tasks/status_buttons", task: task %>
     <!-- ⚠️ 現在の実装では、投稿ボタンはform_with外に設置している。もし完了ボタンを廃止する場合には、form_with内に投稿ボタンを移動する。 -->
-    <button type="submit" form="post_form_<%= task.id %>" class="btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none">
+    <button type="submit" form="post_form_<%= task.id %>" class="btn bg-custom-green hover:bg-custom-green/80 text-white border-none">
       投稿
     </button>
   </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,13 +1,13 @@
 <div class="chat chat-start">
   <div class="chat-header">
-    <span class="text-sm font-medium text-custom-brown">
+    <span class="text-sm font-medium text-custom-dark-green">
       <%= post.user.name %>
     </span>
-    <span class="text-xs text-custom-brown/70 ml-2">
+    <span class="text-xs text-custom-dark-green/70 ml-2">
       <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
     </span>
   </div>
-  <div class="chat-bubble bg-custom-sage text-custom-cream border-none">
+  <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none">
     <%= post.postable.body %>
   </div>
 </div> 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div class="alert bg-custom-cream border border-custom-brown text-custom-brown mb-4">
+  <div class="alert bg-custom-white border border-custom-rust text-custom-rust mb-4">
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.0" stroke="currentColor" class="size-5">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,19 +1,22 @@
-<header class="bg-custom-brown">
+<header class="bg-custom-white rounded-lg">
   <div class="flex justify-between items-center p-4 gap-10">
     <%= link_to root_path do %>
-      <%= image_tag "logo.png", class: "flex-none size-16" %>
+      <%= image_tag "logo.png", class: "flex-none size-6" %>
     <% end %>
     <% if !auth_page? %>
       <div class="flex-1 flex justify-start items-center gap-10">
-        <%= link_to "タスクをみる", tasks_path, class: "text-custom-cream hover:text-custom-cream transition-colors" %>
+        <%= link_to "タスクをみる", tasks_path, class: "text-custom-dark-green hover:text-custom-dark-green transition-colors" %>
         <!-- マイリスト画面とさがす画面はまだ実装していないので、クリックしたらアラートが表示されるようにしている。 -->
-        <%= link_to "マイリスト", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-cream hover:text-custom-cream transition-colors" %>
-        <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-cream hover:text-custom-cream transition-colors" %>
+        <%= link_to "マイリスト", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-dark-green hover:text-custom-dark-green transition-colors" %>
+        <%= link_to "さがす", "#", onclick: "alert('Coming soon!'); return false;", class: "text-custom-dark-green hover:text-custom-dark-green transition-colors" %>
       </div>
       <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "flex-none btn bg-custom-sage border-custom-sage hover:bg-custom-sage-light hover:border-custom-sage-light text-custom-cream" %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "flex-none btn btn-sm bg-custom-dark-green border-custom-dark-green hover:bg-custom-dark-green/80 hover:border-custom-dark-green/80 text-sm text-white rounded-full" %>
       <% else %>
-        <%= link_to "ログイン", new_user_session_path, class: "flex-none btn bg-custom-sage border-custom-sage hover:bg-custom-sage-light hover:border-custom-sage-light text-custom-cream" %>
+        <div class="flex-none flex gap-2">
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-sm bg-custom-dark-green border-custom-dark-green hover:bg-custom-dark-green/80 hover:border-custom-dark-green/80 text-sm text-white rounded-full" %>
+          <%= link_to "サインアップ", new_user_registration_path, class: "btn btn-sm btn-outline bg-custom-white border-custom-dark-green text-sm text-custom-dark-green hover:bg-custom-dark-green hover:text-white rounded-full" %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,15 +1,15 @@
-<div class="flex flex-col items-center h-full gap-10 my-10 bg-custom-cream min-h-screen">
+<div class="flex flex-col items-center h-full gap-10 p-10 bg-custom-white rounded-lg min-h-screen">
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
   </div>
-  <%= link_to "タスクをみる", tasks_path, class: "btn bg-custom-sage border-custom-sage hover:bg-custom-sage-white hover:border-custom-sage-white text-custom-cream" %>
+  <%= link_to "タスクをみる", tasks_path, class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" %>
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
   </div>
   <div class="flex items-center justify-center flex-1 gap-x-10">
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
-    <div class="bg-custom-beige w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
+    <div class="bg-custom-off-white w-60 h-60 rounded-lg shadow-md"></div>
   </div>
 </div>

--- a/app/views/tasks/_complete_button.html.erb
+++ b/app/views/tasks/_complete_button.html.erb
@@ -1,6 +1,6 @@
 <%= button_to toggle_status_task_path(task), 
     method: :patch, 
-    class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" do %>
+    class: "btn btn-outline bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white" do %>
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
     <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
   </svg>

--- a/app/views/tasks/_return_to_doing_button.html.erb
+++ b/app/views/tasks/_return_to_doing_button.html.erb
@@ -1,6 +1,6 @@
 <%= button_to toggle_status_task_path(task), 
     method: :patch, 
-    class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" do %>
+    class: "btn btn-outline bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white" do %>
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
     <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
   </svg>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="flex flex-col items-center my-10 bg-custom-cream min-h-screen">
-  <div class="card bg-custom-beige shadow-xl max-w-2xl w-full border border-custom-brown/20">
+<div class="flex flex-col items-center py-10 bg-custom-white rounded-lg min-h-screen">
+  <div class="card bg-custom-white shadow-xl max-w-2xl w-full border border-custom-light-gray/50">
     <div class="card-body">      
       <!-- エラーメッセージ表示エリア -->
       <%= render 'shared/error_messages', object: @task %>
@@ -7,12 +7,12 @@
       <%= form_with model: @task, local: true, html: { class: "flex flex-col gap-6" } do |f| %>
         <!-- タイトル入力フィールド -->
         <div class="form-control">
-          <%= f.label :title, class: "label text-custom-brown font-medium" %>
+          <%= f.label :title, class: "label text-custom-dark-green font-medium" %>
           <div class="join w-full">
-            <%= f.text_field :title, class: "input input-bordered join-item flex-1 bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+            <%= f.text_field :title, class: "input input-bordered join-item flex-1 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none" %>
             <!-- ♻️onclickイベントは改善の余地あり。今後Stimulusコントローラーで実装予定 -->
             <button type="button" 
-                    class="btn btn-square join-item bg-custom-brown hover:bg-custom-brown-light text-custom-cream border-none"
+                    class="btn btn-square join-item bg-custom-dark-green hover:bg-custom-dark-green/80 text-white border-none"
                     onclick="document.getElementById('task_title').value = ''">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
                 <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
@@ -23,7 +23,7 @@
 
         <!-- タグ選択セクション -->
         <div class="form-control">
-          <%= f.label :tag_ids, class: "label text-custom-brown font-medium" %>
+          <%= f.label :tag_ids, class: "label text-custom-dark-green font-medium" %>
           <!-- タグ選択ドロップダウン -->
           <div class="dropdown">
             <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus
@@ -35,7 +35,7 @@
             </div>
             -->
             <!-- ⚠️buttonタグを使用した場合、safariブラウザでは動作しない可能性がある。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
-            <button type="button" class="btn btn-outline w-full bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream">
+            <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
@@ -43,16 +43,16 @@
             </button>
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
-            <ul tabindex="0" class="dropdown-content bg-custom-cream rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-sage/20">
+            <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">
               <% Tag.all.each do |tag| %>
                 <li class="rounded p-1">
-                  <label class="flex items-center gap-2 text-custom-brown hover:bg-custom-beige hover:text-custom-brown rounded cursor-pointer p-1 transition-colors duration-200">
+                  <label class="flex items-center gap-2 text-custom-dark-green hover:bg-custom-light-gray hover:text-custom-dark-green rounded cursor-pointer p-1 transition-colors duration-200">
                     <input type="checkbox" 
                             name="task[tag_ids][]" 
                             value="<%= tag.id %>"
                             <%= 'checked' if @task.tag_ids.include?(tag.id) %>
-                            class="checkbox bg-custom-cream border-custom-brown"
-                            style="--chkbg: #674636; --chkfg: #FFF8E8;">
+                            class="checkbox bg-custom-white border-custom-dark-green"
+                            style="--chkbg: #233D31; --chkfg: #FCFCF9;">
                     <span><%= tag.name %></span>
                   </label>
                 </li>
@@ -68,8 +68,8 @@
         <div class="form-control">
           <div class="flex items-center justify-between mb-3">
             <!-- ♻️ここはf.labelに変更予定 -->
-            <%= f.label :todos, class: "label text-custom-brown font-medium" %>
-            <button type="button" class="btn btn-ghost btn-sm bg-custom-brown hover:bg-custom-brown-light text-custom-cream border-none" onclick="addTodoField()">
+            <%= f.label :todos, class: "label text-custom-dark-green font-medium" %>
+            <button type="button" class="btn btn-ghost btn-sm bg-custom-dark-green hover:bg-custom-dark-green/80 text-white border-none" onclick="addTodoField()">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
               </svg>
@@ -83,7 +83,7 @@
               <div class="flex items-center gap-2">                
                 <!-- 削除ボタン -->
                 <button type="button" 
-                        class="btn btn-circle btn-outline btn-sm bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream"
+                        class="btn btn-circle btn-outline btn-sm border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent"
                         onclick="removeTodoField(this)">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                     <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
@@ -92,7 +92,7 @@
                 <!-- todo入力フィールド -->
                 <%= todo_form.text_field :body, 
                     placeholder: "やることを入力してください", 
-                    class: "input input-bordered flex-1 bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+                    class: "input input-bordered flex-1 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
                 <%= todo_form.hidden_field :id %>
                 <%= todo_form.hidden_field :_destroy, class: "hidden" %>
               </div>
@@ -102,8 +102,8 @@
 
         <!-- アクションボタン -->
         <div class="flex justify-end gap-4 mt-6">
-          <%= link_to "戻る", task_path(@task), class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" %>
-          <%= f.submit "変更", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none" %>
+          <%= link_to "戻る", task_path(@task), class: "btn btn-outline border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent" %>
+          <%= f.submit "変更", class: "btn bg-custom-green hover:bg-custom-green/80 text-white border-none" %>
         </div>
       <% end %>
     </div>
@@ -121,7 +121,7 @@ function addTodoField() {
   const newTodoHtml = `
     <div class="flex items-center gap-2">
       <button type="button" 
-              class="btn btn-circle btn-outline btn-sm bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream"
+              class="btn btn-circle btn-outline btn-sm border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent"
               onclick="removeTodoField(this)">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
           <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
@@ -131,7 +131,7 @@ function addTodoField() {
       <input type="text" 
               name="task[todos_attributes][${todoCount}][body]" 
               placeholder="やることを入力してください" 
-              class="input input-bordered flex-1 bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50">
+              class="input input-bordered flex-1 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50">
       <input type="hidden" name="task[todos_attributes][${todoCount}][id]" value="">
     </div>
   `;

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
-<div class="flex flex-col h-full gap-10 mx-20 my-10 bg-custom-cream min-h-screen">
-  <p class="text-4xl font-bold text-custom-brown text-center">タスク</p>
+<div class="flex flex-col h-full gap-10 px-20 py-10 bg-custom-white rounded-lg min-h-screen">
+  <p class="text-4xl font-bold text-custom-dark-green text-center">タスク</p>
   <div class="flex justify-end gap-4">
-    <%= link_to new_task_path, class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" do %>
+    <%= link_to new_task_path, class: "btn btn-outline border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent" do %>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
         <path d="M10.75 4.75a.75.75 0 0 0-1.5 0v4.5h-4.5a.75.75 0 0 0 0 1.5h4.5v4.5a.75.75 0 0 0 1.5 0v-4.5h4.5a.75.75 0 0 0 0-1.5h-4.5v-4.5Z" />
       </svg>
@@ -12,22 +12,22 @@
   <% if @tasks.any? %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <% @tasks.each do |task| %>
-        <%= link_to task_path(task), class: "card bg-custom-beige shadow-xl hover:shadow-2xl transition-shadow duration-300 border border-custom-sage/20 h-48" do %>
+        <%= link_to task_path(task), class: "card bg-custom-white shadow-xl hover:shadow-2xl transition-shadow duration-300 border border-custom-light-gray/50 h-48" do %>
           <div class="card-body flex flex-col h-full p-6">
             <div class="flex-1">
-              <p class="card-title text-lg text-custom-brown line-clamp-2 mb-2"><%= task.title %></p>
+              <p class="card-title text-lg text-custom-dark-green line-clamp-2 mb-2"><%= task.title %></p>
               
               <% if task.tags.any? %>
                 <div class="flex flex-wrap gap-2">
                   <% task.tags.each do |tag| %>
-                    <span class="badge bg-custom-sage text-custom-cream border-none"><%= tag.name %></span>
+                    <span class="badge bg-custom-dark-green text-custom-white border-none"><%= tag.name %></span>
                   <% end %>
                 </div>
               <% end %>
             </div>
             
             <div class="mt-auto">
-              <p class="text-sm text-custom-brown/70 text-right">
+              <p class="text-sm text-custom-dark-green/70 text-right">
                 作成日: <%= task.created_at.strftime("%Y年%m月%d日 %H:%M") %>
               </p>
             </div>
@@ -37,7 +37,7 @@
     </div>
   <% else %>
     <div class="text-center py-10">
-      <p class="text-custom-brown/60">タスクがありません</p>
+      <p class="text-custom-dark-green/60">タスクがありません</p>
     </div>
   <% end %>
 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,5 @@
-<div class="flex flex-col items-center my-10 bg-custom-cream min-h-screen">
-  <div class="card bg-custom-beige shadow-xl max-w-2xl w-full border border-custom-brown/20">
+<div class="flex flex-col items-center py-10 bg-custom-white rounded-lg min-h-screen">
+  <div class="card bg-custom-white shadow-xl max-w-2xl w-full border border-custom-light-gray/50">
     <div class="card-body">      
       <!-- エラーメッセージ表示エリア -->
       <%= render 'shared/error_messages', object: @task %>
@@ -7,12 +7,12 @@
       <%= form_with model: @task, local: true, html: { class: "flex flex-col gap-6" } do |f| %>
         <!-- タイトル入力フィールド -->
         <div class="form-control">
-          <%= f.label :title, class: "label text-custom-brown font-medium" %>
+          <%= f.label :title, class: "label text-custom-dark-green font-medium" %>
           <div class="join w-full">
-            <%= f.text_field :title, class: "input input-bordered join-item flex-1 bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none" %>
+            <%= f.text_field :title, class: "input input-bordered join-item flex-1 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none" %>
             <!-- ♻️onclickイベントは改善の余地あり。今後Stimulusコントローラーで実装予定 -->
             <button type="button" 
-                    class="btn btn-square join-item bg-custom-brown hover:bg-custom-brown-light text-custom-cream border-none"
+                    class="btn btn-square join-item bg-custom-dark-green hover:bg-custom-dark-green/80 text-white border-none"
                     onclick="document.getElementById('task_title').value = ''">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
                 <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
@@ -23,7 +23,7 @@
 
         <!-- タグ選択セクション -->
         <div class="form-control">
-          <%= f.label :tag_ids, class: "label text-custom-brown font-medium" %>
+          <%= f.label :tag_ids, class: "label text-custom-dark-green font-medium" %>
           <!-- タグ選択ドロップダウン -->
           <div class="dropdown">
             <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus
@@ -35,7 +35,7 @@
             </div>
             -->
             <!-- ⚠️buttonタグを使用した場合、safariブラウザでは動作しない可能性がある。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
-            <button type="button" class="btn btn-outline w-full bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream">
+            <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
@@ -43,15 +43,15 @@
             </button>
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
-            <ul tabindex="0" class="dropdown-content bg-custom-cream rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-sage/20">
+            <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">
               <% Tag.all.each do |tag| %>
                 <li class="rounded p-1">
-                  <label class="flex items-center gap-2 text-custom-brown hover:bg-custom-beige hover:text-custom-brown rounded cursor-pointer p-1 transition-colors duration-200">
+                  <label class="flex items-center gap-2 text-custom-dark-green hover:bg-custom-light-gray hover:text-custom-dark-green rounded cursor-pointer p-1 transition-colors duration-200">
                     <input type="checkbox" 
                             name="task[tag_ids][]" 
                             value="<%= tag.id %>"
-                            class="checkbox bg-custom-cream border-custom-brown"
-                            style="--chkbg: #674636; --chkfg: #FFF8E8;">
+                            class="checkbox bg-custom-white border-custom-dark-green"
+                            style="--chkbg: #233D31; --chkfg: #FCFCF9;">
                     <span><%= tag.name %></span>
                   </label>
                 </li>
@@ -62,8 +62,8 @@
 
         <!-- ボタンセクション -->
         <div class="flex justify-end gap-4 mt-6">
-          <%= link_to "戻る", tasks_path, class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" %>
-          <%= f.submit "作成", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none" %>
+          <%= link_to "戻る", tasks_path, class: "btn btn-outline border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent" %>
+          <%= f.submit "作成", class: "btn bg-custom-green hover:bg-custom-green/80 text-white border-none" %>
         </div>
       <% end %>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,15 +1,16 @@
-<div class="bg-custom-beige rounded-lg shadow-lg p-6 relative m-10 border border-custom-brown/20">
+<div class="flex flex-col h-full gap-10 px-20 py-10 bg-custom-white rounded-lg min-h-screen">
+<div class="bg-custom-white rounded-lg shadow-lg p-6 relative border border-custom-light-gray/50">
   <!-- 🐛 タスク項目カードの内容をパーシャルに移したが、二重でtodoリストが表示されるバグが発生しており、hotwireのturbo_frameが影響を及ぼしている可能性が高い -->
   <%#= render "tasks/task_content" %>
   <!-- タイトル -->
   <div class="flex flex-col gap-4">
     <div class="flex justify-between gap-12">
-      <p class="text-2xl font-bold mb-6 text-custom-brown">
+      <p class="text-2xl font-bold mb-6 text-custom-dark-green">
         <%= @task.title %>
       </p>
 
       <!-- 編集ボタン -->
-      <%= link_to edit_task_path(@task), class: "btn btn-outline bg-custom-cream border-custom-brown text-custom-brown hover:bg-custom-brown hover:text-custom-cream" do %>
+      <%= link_to edit_task_path(@task), class: "btn btn-outline border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white bg-transparent" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
         </svg>
@@ -21,7 +22,7 @@
     <% if @task.tags.any? %>
       <div class="flex flex-wrap gap-2 mb-8">
         <% @task.tags.each do |tag| %>
-          <span class="badge bg-custom-sage text-custom-cream border-none">#<%= tag.name %></span>
+          <span class="badge bg-custom-dark-green text-custom-white border-none"><%= tag.name %></span>
         <% end %>
       </div>
     <% end %>
@@ -36,20 +37,20 @@
 </div>
 
 <!-- 投稿一覧 -->
-<div class="p-6 m-10">
+<div class="p-6">
   <% if @posts.any? %>
     <div class="space-y-4">
       <%#= render @posts の記述では、scan_rubyのエラーが発生するため、以下のようにパーシャルは明示的に指定 %> 
       <%= render partial: "posts/post", collection: @posts %>
     </div>
   <% else %>
-    <div class="text-center py-8 text-custom-brown/60">
+    <div class="text-center py-8 text-custom-dark-green/60">
       <p>まだ投稿はありません</p>
     </div>
   <% end %>
 </div>
 
 <!-- 投稿フォーム -->
-<div class="bg-custom-beige rounded-lg shadow-lg p-6 m-10 border border-custom-brown/20">
+<div class="bg-custom-white rounded-lg shadow-lg p-6 border border-custom-light-gray/50">
   <%= render 'posts/form', task: @task, post: @post %>
 </div>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag todo do %>
   <%= form_with model: [todo.task, todo], local: false, class: "flex items-center gap-2" do |f| %>
     <%= f.check_box :done, 
-        class: "checkbox bg-custom-cream border-custom-brown", 
+        class: "checkbox bg-custom-white border-custom-dark-green", 
         checked: todo.done?,
         data: { action: "change->todo-toggle#toggle" },
-        style: "--chkbg: #674636; --chkfg: #FFF8E8;" %>
-    <span class="<%= todo.done? ? 'line-through text-custom-brown/50' : 'text-custom-brown' %>">
+        style: "--chkbg: #233D31; --chkfg: #FCFCF9;" %>
+    <span class="<%= todo.done? ? 'line-through text-custom-dark-green/50' : 'text-custom-dark-green' %>">
       <%= todo.body %>
     </span>
   <% end %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -14,14 +14,12 @@ module.exports = {
       },
       colors: {
         custom: {
-          cream: "#FFF8E8", // 背景、テキスト
-          beige: "#F7EED3", // カード
-          sage: "#AAB396", // 基準色
-          "sage-light": "#C4D1B8", // sageより10%明度が明るい
-          "sage-dark": "#8A9A7A", // sageより10%明度が暗い
-          brown: "#674636", // ヘッダー、フッター
-          "brown-light": "#7A5646", // brownより明度10%明るい
-          "brown-dark": "#543628", // brownより明度10%暗い
+          green: "#148F57", // Green
+          "dark-green": "#233D31", // Dark Green
+          "light-gray": "#E8E8E2", // Light Gray
+          "off-white": "#F3F3ED", // Off White
+          white: "#FCFCF9", // White
+          rust: "#A94B2E", // Rust
         },
       },
     },


### PR DESCRIPTION
## 概要
ヘッダーとタスク関連画面の配色・スタイルを修正し、モダンなUIに改善する。

### 関連branch, issue
- #66 
- #102 

### 新しいカラーパレット

<img width="2458" height="1466" alt="Image" src="https://github.com/user-attachments/assets/0aed9ee2-d73c-45ca-ae54-dcdc64faa0c9" />

## 実装
### トップ画面
<img width="2809" height="1671" alt="image" src="https://github.com/user-attachments/assets/6a1a673e-e4cd-4452-8b0f-b166323e45be" />

### タスク一覧画面
<img width="2810" height="1666" alt="image" src="https://github.com/user-attachments/assets/278b54b4-83c7-4ce5-80cd-c9d040e5fc50" />


### タスク新規作成画面
<img width="2834" height="1670" alt="image" src="https://github.com/user-attachments/assets/1fcd4fdb-06dc-4ab9-af7b-5a6bd475082b" />


### タスク詳細画面
<img width="2827" height="1684" alt="image" src="https://github.com/user-attachments/assets/cf78c68d-70fb-41ac-925e-10dd42457440" />


### タスク編集画面
<img width="2822" height="1679" alt="image" src="https://github.com/user-attachments/assets/059e96a2-d537-46e2-9c62-5908535d9981" />

## 今後の実装
- 認証画面の配色