### PR TITLE
【認証画面】配色とスタイルを修正し、モダンなUIに改善

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,41 +1,41 @@
-<div class="bg-custom-cream flex items-center justify-center py-10">
-  <div class="bg-custom-beige rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-brown/20">
+<div class="bg-custom-white rounded-lg flex items-center justify-center py-10">
+  <div class="bg-custom-white rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-light-gray/50">
     <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
-      <p class="text-2xl font-bold text-custom-brown">新規登録</p>
+      <p class="text-2xl font-bold text-custom-dark-green">新規登録</p>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
         <%= render "users/shared/error_messages", resource: resource %>
 
         <div class="field w-full">
-          <%= f.label :name, class: "text-custom-brown font-medium" %><br />
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.label :name, class: "text-custom-dark-green font-medium" %><br />
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "name", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <div class="field w-full">
-          <%= f.label :email, class: "text-custom-brown font-medium" %><br />
-          <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.label :email, class: "text-custom-dark-green font-medium" %><br />
+          <%= f.email_field :email, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <div class="field w-full">
-          <%= f.label :password, class: "text-custom-brown font-medium" %>
+          <%= f.label :password, class: "text-custom-dark-green font-medium" %>
           <% if @minimum_password_length %>
-            <p class="text-sm text-custom-brown/60"><%= @minimum_password_length %> characters minimum</p>
+            <p class="text-sm text-custom-dark-green/60"><%= @minimum_password_length %> characters minimum</p>
           <% end %>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <div class="field w-full">
-          <%= f.label :password_confirmation, class: "text-custom-brown font-medium" %><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.label :password_confirmation, class: "text-custom-dark-green font-medium" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password(confirmation)", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <div class="actions flex justify-center w-full">
-          <%= f.submit "新規登録", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full" %>
+          <%= f.submit "新規登録", class: "btn bg-custom-green hover:bg-custom-green/80 text-white border-none w-full" %>
         </div>
       <% end %>
 
       <div class="flex justify-center gap-10">
-        <%= link_to "すでにアカウントをお持ちですか？ - ログイン", new_session_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
+        <%= link_to "すでにアカウントをお持ちですか？ - ログイン", new_session_path(resource_name), class: "text-xs font-semibold text-custom-dark-green underline hover:text-custom-dark-green/80" %>
       </div>
     </div>
   </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,52 +1,52 @@
-<div class="bg-custom-cream flex items-center justify-center py-10">
-  <div class="bg-custom-beige rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-brown/20">
+<div class="bg-custom-white rounded-lg flex items-center justify-center py-10">
+  <div class="bg-custom-white rounded-lg shadow-lg px-12 py-6 relative mx-auto max-w-md border border-custom-light-gray/50">
     <div class="flex flex-col items-center h-full gap-5 my-5 w-full">
-      <p class="text-2xl font-bold text-custom-brown">ログイン</p>
+      <p class="text-2xl font-bold text-custom-dark-green">ログイン</p>
 
       <%= form_with url: guest_session_path, method: :post, html: { class: "w-full" } do |f| %>
-        <button type="submit" class="btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full">
+        <button type="submit" class="btn bg-custom-dark-green hover:bg-custom-dark-green/80 text-white border-none w-full">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
             <path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd" />
           </svg>
-          ゲストとしてアクセス
+          ゲストとしてログイン
         </button>
       <% end %>
 
       <!-- 区切り線 -->
       <div class="flex items-center w-full">
-        <div class="flex-1 border-t border-custom-brown/30"></div>
-        <span class="px-4 text-sm text-custom-brown/60">または</span>
-        <div class="flex-1 border-t border-custom-brown/30"></div>
+        <div class="flex-1 border-t border-custom-light-gray/50"></div>
+        <span class="px-4 text-sm text-custom-dark-green/60">または</span>
+        <div class="flex-1 border-t border-custom-light-gray/50"></div>
       </div>
       
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
         <div class="field w-full">
-          <%= f.label :email, class: "text-custom-brown font-medium" %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.label :email, class: "text-custom-dark-green font-medium" %><br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <div class="field w-full">
-          <%= f.label :password, class: "text-custom-brown font-medium" %><br />
-          <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-bordered w-full bg-custom-cream border-custom-brown text-custom-brown focus:border-custom-brown-light focus:outline-none placeholder:text-custom-brown/50" %>
+          <%= f.label :password, class: "text-custom-dark-green font-medium" %><br />
+          <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="form-control w-full">
             <label class="label cursor-pointer">
-              <%= f.check_box :remember_me, class: "checkbox bg-custom-cream border-custom-brown", style: "--chkbg: #674636; --chkfg: #FFF8E8;" %>
-              <span class="label-text text-custom-brown">ログイン状態を保持</span>
+              <%= f.check_box :remember_me, class: "checkbox bg-custom-white border-custom-dark-green", style: "--chkbg: #233D31; --chkfg: #FCFCF9;" %>
+              <span class="label-text text-custom-dark-green">ログイン状態を保持</span>
             </label>
           </div>
         <% end %>
 
         <div class="actions flex justify-center w-full">
-          <%= f.submit "ログイン", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none w-full" %>
+          <%= f.submit "ログイン", class: "btn bg-custom-green hover:bg-custom-green/80 text-white border-none w-full" %>
         </div>
       <% end %>
 
       <div class="flex justify-center gap-10">
-        <%= link_to "新規アカウントを作成", new_registration_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
-        <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "text-xs font-semibold text-custom-brown underline hover:text-custom-brown-light" %>
+        <%= link_to "新規アカウントを作成", new_registration_path(resource_name), class: "text-xs font-semibold text-custom-dark-green underline hover:text-custom-dark-green/80" %>
+        <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "text-xs font-semibold text-custom-dark-green underline hover:text-custom-dark-green/80" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
認証画面の配色とスタイルを修正し、モダンなUIに改善した。
### 関連するbranch, issue
- #102
- #104

## 実装
### ログイン画面
<img width="2829" height="1652" alt="image" src="https://github.com/user-attachments/assets/a53d3eab-edda-4789-ac33-2d2d1e8a9b65" />


### 新規登録画面
<img width="2826" height="1678" alt="image" src="https://github.com/user-attachments/assets/a233a29f-0464-4fc7-81cc-42963b30d306" />
